### PR TITLE
feat(frontend): add federation ER diagram visualization to subgraph-composer

### DIFF
--- a/frontend/subgraph-composer/dist/index.html
+++ b/frontend/subgraph-composer/dist/index.html
@@ -17,8 +17,7 @@
         width: 100%;
         height: 100%;
         font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          "Helvetica Neue", Arial, sans-serif;
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
         background: #f5f5f5;
       }
 
@@ -26,8 +25,8 @@
         overflow: hidden;
       }
     </style>
-    <script type="module" crossorigin src="/assets/index-BnB7WAjB.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BRpYNB6r.css">
+    <script type="module" crossorigin src="/assets/index-DbTL3qE2.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-B-OCy-ku.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/subgraph-composer/package.json
+++ b/frontend/subgraph-composer/package.json
@@ -39,6 +39,7 @@
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@visual-json/core": "workspace:*",
     "@visual-json/react": "workspace:*",
+    "@xyflow/react": "^12.11.0",
     "graphql": "^16.14.0",
     "graphql-editor": "^7.3.1",
     "react": "^18.3.1",

--- a/frontend/subgraph-composer/src/App.jsx
+++ b/frontend/subgraph-composer/src/App.jsx
@@ -411,7 +411,6 @@ export default function App() {
                   <Suspense fallback={<div className="empty-state">Loading ER diagram...</div>}>
                     <ERDiagramPanel
                       supergraphSDL={supergraphSDL}
-                      subgraphsMap={subgraphsMap}
                       schemas={schemas}
                       typeSources={typeSources}
                     />

--- a/frontend/subgraph-composer/src/App.jsx
+++ b/frontend/subgraph-composer/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, Suspense } from "react";
 import SplitPane from "react-split-pane";
 import "./App.css";
 import SchemaManager from "./components/SchemaManager.jsx";
@@ -15,8 +15,12 @@ import { useDirectiveSuggestions } from "./hooks/useDirectiveSuggestions.js";
 import { useSettings } from "./hooks/useSettings.js";
 import { getTemplate } from "./lib/templates.js";
 
+// Lazy-load ER diagram panel to avoid bundling @xyflow/react on initial load
+const ERDiagramPanel = React.lazy(() => import("./components/ERDiagramPanel.jsx"));
+
 export default function App() {
   const [showSettings, setShowSettings] = useState(false);
+  const [activeTab, setActiveTab] = useState("editor"); // "editor" | "visualize" | "er"
 
   const {
     schemas,
@@ -33,7 +37,7 @@ export default function App() {
 
   const { generateSubgraph, subgraphs, subgraphsMap, isLoading } = useSubgraphGenerator();
 
-  const { supergraphSDL, compositionStats, compositionErrors, compose } = useComposition();
+  const { supergraphSDL, compositionStats, compositionErrors, typeSources, compose } = useComposition();
 
   const {
     suggestions,
@@ -294,45 +298,124 @@ export default function App() {
                 )}
               </div>
               <div className="editor-section">
-                {/* Subgraph Editor for the active subgraph with SDL/Stats */}
-                {subgraphs && subgraphs.length > 0 ? (
-                  <SubgraphEditor
-                    subgraph={{
-                      name: activeSchema?.name || "Subgraph 1",
-                      content: subgraphs[0].sdl || "",
-                    }}
-                    onUpdate={(content) => {
-                      /* TODO: implement subgraph update logic */
-                    }}
-                    isLoading={isLoading}
-                    sdl={supergraphSDL}
-                    stats={compositionStats}
-                    errors={compositionErrors}
-                    schemas={schemas}
-                    subgraphCount={subgraphs.length}
-                  />
-                ) : (
-                  <div
-                    className="schema-editor"
+                {/* Tab bar to switch between Preview, Visualize, and ER Diagram */}
+                <div
+                  style={{
+                    display: "flex",
+                    gap: 0,
+                    borderBottom: "1px solid var(--color-border)",
+                    background: "var(--color-bg-secondary)",
+                    flexShrink: 0,
+                  }}
+                >
+                  <button
+                    className={`tab-btn ${activeTab === "editor" ? "active" : ""}`}
+                    onClick={() => setActiveTab("editor")}
                     style={{
-                      height: "100%",
-                      display: "flex",
-                      flexDirection: "column",
-                      justifyContent: "center",
-                      alignItems: "center",
-                      background: "white",
-                      borderRadius: "var(--radius-md)",
-                      boxShadow: "var(--shadow-sm)",
-                      border: "1px solid var(--color-border)",
+                      padding: "var(--spacing-sm) var(--spacing-md)",
+                      border: "none",
+                      background: activeTab === "editor" ? "white" : "transparent",
+                      cursor: "pointer",
+                      fontSize: "0.875rem",
+                      fontWeight: activeTab === "editor" ? "600" : "400",
+                      color: "var(--color-text)",
+                      borderBottom: activeTab === "editor" ? "2px solid var(--color-primary)" : "2px solid transparent",
                     }}
                   >
-                    <div className="editor-header">
-                      <div className="editor-title">Subgraph Preview</div>
-                    </div>
+                    Preview
+                  </button>
+                  <button
+                    className={`tab-btn ${activeTab === "visualize" ? "active" : ""}`}
+                    onClick={() => setActiveTab("visualize")}
+                    style={{
+                      padding: "var(--spacing-sm) var(--spacing-md)",
+                      border: "none",
+                      background: activeTab === "visualize" ? "white" : "transparent",
+                      cursor: "pointer",
+                      fontSize: "0.875rem",
+                      fontWeight: activeTab === "visualize" ? "600" : "400",
+                      color: "var(--color-text)",
+                      borderBottom: activeTab === "visualize" ? "2px solid var(--color-primary)" : "2px solid transparent",
+                    }}
+                  >
+                    Visualize
+                  </button>
+                  <button
+                    className={`tab-btn ${activeTab === "er" ? "active" : ""}`}
+                    onClick={() => setActiveTab("er")}
+                    style={{
+                      padding: "var(--spacing-sm) var(--spacing-md)",
+                      border: "none",
+                      background: activeTab === "er" ? "white" : "transparent",
+                      cursor: "pointer",
+                      fontSize: "0.875rem",
+                      fontWeight: activeTab === "er" ? "600" : "400",
+                      color: "var(--color-text)",
+                      borderBottom: activeTab === "er" ? "2px solid var(--color-primary)" : "2px solid transparent",
+                    }}
+                  >
+                    ER Diagram
+                  </button>
+                </div>
+
+                {activeTab === "editor" ? (
+                  <>
+                    {/* Subgraph Editor for the active subgraph with SDL/Stats */}
+                    {subgraphs && subgraphs.length > 0 ? (
+                      <SubgraphEditor
+                        subgraph={{
+                          name: activeSchema?.name || "Subgraph 1",
+                          content: subgraphs[0].sdl || "",
+                        }}
+                        onUpdate={(content) => {
+                          /* TODO: implement subgraph update logic */
+                        }}
+                        isLoading={isLoading}
+                        sdl={supergraphSDL}
+                        stats={compositionStats}
+                        errors={compositionErrors}
+                        schemas={schemas}
+                        subgraphCount={subgraphs.length}
+                      />
+                    ) : (
+                      <div
+                        className="schema-editor"
+                        style={{
+                          height: "100%",
+                          display: "flex",
+                          flexDirection: "column",
+                          justifyContent: "center",
+                          alignItems: "center",
+                          background: "white",
+                          borderRadius: "var(--radius-md)",
+                          boxShadow: "var(--shadow-sm)",
+                          border: "1px solid var(--color-border)",
+                        }}
+                      >
+                        <div className="editor-header">
+                          <div className="editor-title">Subgraph Preview</div>
+                        </div>
+                        <div className="empty-state">
+                          <p>Click "Generate" to create a subgraph</p>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                ) : activeTab === "visualize" ? (
+                  <Suspense fallback={<div className="empty-state">Loading visualization...</div>}>
                     <div className="empty-state">
-                      <p>Click "Generate" to create a subgraph</p>
+                      <p>Voyager visualization is not available in this build.</p>
                     </div>
-                  </div>
+                  </Suspense>
+                ) : (
+                  <Suspense fallback={<div className="empty-state">Loading ER diagram...</div>}>
+                    <ERDiagramPanel
+                      supergraphSDL={supergraphSDL}
+                      subgraphsMap={subgraphsMap}
+                      schemas={schemas}
+                      typeSources={typeSources}
+                    />
+                  </Suspense>
                 )}
               </div>
             </SplitPane>

--- a/frontend/subgraph-composer/src/__tests__/erDiagram.test.js
+++ b/frontend/subgraph-composer/src/__tests__/erDiagram.test.js
@@ -1,0 +1,193 @@
+/**
+ * Tests for ER diagram parser and Mermaid export
+ */
+
+import {
+  parseERDiagram,
+  generateMermaidER,
+  exportMermaidER,
+  FEDERATION_DIRECTIVES,
+  DIRECTIVE_EDGE_STYLES,
+  SUBGRAPH_COLORS,
+} from "../lib/erDiagramParser.js";
+
+describe("ER Diagram Parser", () => {
+  const sampleSDL = `
+    type Product @key(fields: "id") {
+      id: ID!
+      name: String
+      sku: String @external
+      reviews: [Review] @requires(fields: "sku")
+    }
+
+    type Review {
+      id: ID!
+      rating: Int
+      product: Product @shareable
+    }
+  `;
+
+  const schemas = [
+    { id: "schema1", name: "Catalog" },
+    { id: "schema2", name: "Reviews" },
+  ];
+
+  const typeSources = {
+    Product: ["schema1"],
+    Review: ["schema2"],
+  };
+
+  test("parseERDiagram returns nodes, edges, and subgraphs", () => {
+    const result = parseERDiagram(sampleSDL, typeSources, schemas);
+    expect(result.nodes.length).toBeGreaterThan(0);
+    expect(Array.isArray(result.edges)).toBe(true);
+    expect(Array.isArray(result.subgraphs)).toBe(true);
+  });
+
+  test("nodes have entityNode type with label and fields", () => {
+    const result = parseERDiagram(sampleSDL, typeSources, schemas);
+    const productNode = result.nodes.find((n) => n.data.label === "Product");
+    expect(productNode).toBeDefined();
+    expect(productNode.type).toBe("entityNode");
+    expect(productNode.data.fields.length).toBeGreaterThan(0);
+    expect(productNode.data.fields.some((f) => f.name === "id")).toBe(true);
+  });
+
+  test("nodes include federation directives on type", () => {
+    const result = parseERDiagram(sampleSDL, typeSources, schemas);
+    const productNode = result.nodes.find((n) => n.data.label === "Product");
+    expect(productNode.data.directives.some((d) => d.name === "@key")).toBe(true);
+  });
+
+  test("fields include federation directives", () => {
+    const result = parseERDiagram(sampleSDL, typeSources, schemas);
+    const productNode = result.nodes.find((n) => n.data.label === "Product");
+    const skuField = productNode.data.fields.find((f) => f.name === "sku");
+    expect(skuField.directives.some((d) => d.name === "@external")).toBe(true);
+  });
+
+  test("edges are created for complex field types", () => {
+    const result = parseERDiagram(sampleSDL, typeSources, schemas);
+    const productToReview = result.edges.find((e) => e.label === "reviews");
+    expect(productToReview).toBeDefined();
+    expect(productToReview.data.directives.some((d) => d.name === "@requires")).toBe(true);
+  });
+
+  test("subgraphs are grouped by source schema", () => {
+    const result = parseERDiagram(sampleSDL, typeSources, schemas);
+    expect(result.subgraphs.length).toBe(2);
+    const catalog = result.subgraphs.find((s) => s.id === "schema1");
+    expect(catalog).toBeDefined();
+    expect(catalog.nodeIds.length).toBe(1);
+  });
+
+  test("handles empty SDL gracefully", () => {
+    const result = parseERDiagram("", {}, []);
+    expect(result.nodes).toEqual([]);
+    expect(result.edges).toEqual([]);
+    expect(result.subgraphs).toEqual([]);
+  });
+
+  test("handles SDL with no federation directives", () => {
+    const plainSDL = `
+      type User {
+        id: ID!
+        name: String
+      }
+    `;
+    const result = parseERDiagram(plainSDL, { User: ["s1"] }, [{ id: "s1", name: "Users" }]);
+    const userNode = result.nodes.find((n) => n.data.label === "User");
+    expect(userNode.data.directives).toEqual([]);
+  });
+
+  test("SUBGRAPH_COLORS has at least 10 colors", () => {
+    expect(SUBGRAPH_COLORS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  test("FEDERATION_DIRECTIVES includes expected directives", () => {
+    expect(FEDERATION_DIRECTIVES).toContain("@key");
+    expect(FEDERATION_DIRECTIVES).toContain("@external");
+    expect(FEDERATION_DIRECTIVES).toContain("@requires");
+    expect(FEDERATION_DIRECTIVES).toContain("@shareable");
+    expect(FEDERATION_DIRECTIVES).toContain("@provides");
+  });
+
+  test("DIRECTIVE_EDGE_STYLES has entries for each directive", () => {
+    for (const d of FEDERATION_DIRECTIVES) {
+      expect(DIRECTIVE_EDGE_STYLES[d]).toBeDefined();
+    }
+  });
+});
+
+describe("Mermaid ER Export", () => {
+  const sampleSDL = `
+    type Product @key(fields: "id") {
+      id: ID!
+      name: String
+      reviews: [Review]
+    }
+
+    type Review {
+      id: ID!
+      rating: Int
+    }
+  `;
+
+  const schemas = [
+    { id: "schema1", name: "Catalog" },
+    { id: "schema2", name: "Reviews" },
+  ];
+
+  const typeSources = {
+    Product: ["schema1"],
+    Review: ["schema2"],
+  };
+
+  test("generateMermaidER returns a string starting with erDiagram", () => {
+    const erData = parseERDiagram(sampleSDL, typeSources, schemas);
+    const mermaid = generateMermaidER(erData);
+    expect(mermaid.startsWith("erDiagram")).toBe(true);
+  });
+
+  test("generateMermaidER includes entity definitions", () => {
+    const erData = parseERDiagram(sampleSDL, typeSources, schemas);
+    const mermaid = generateMermaidER(erData);
+    expect(mermaid).toContain("Product {");
+    expect(mermaid).toContain("Review {");
+  });
+
+  test("generateMermaidER includes field lines with types", () => {
+    const erData = parseERDiagram(sampleSDL, typeSources, schemas);
+    const mermaid = generateMermaidER(erData);
+    expect(mermaid).toContain("ID id");
+    expect(mermaid).toContain("String name");
+  });
+
+  test("generateMermaidER includes relationships", () => {
+    const erData = parseERDiagram(sampleSDL, typeSources, schemas);
+    const mermaid = generateMermaidER(erData);
+    expect(mermaid).toContain("Product ||--|| Review");
+  });
+
+  test("generateMermaidER returns empty string for empty data", () => {
+    expect(generateMermaidER({ nodes: [], edges: [], subgraphs: [] })).toBe("");
+  });
+
+  test("exportMermaidER triggers download", () => {
+    const erData = parseERDiagram(sampleSDL, typeSources, schemas);
+    const createElementSpy = jest.spyOn(document, "createElement");
+    const appendChildSpy = jest.spyOn(document.body, "appendChild");
+    const removeChildSpy = jest.spyOn(document.body, "removeChild");
+
+    const mermaid = exportMermaidER(erData, "test.mmd");
+
+    expect(mermaid).toContain("erDiagram");
+    expect(createElementSpy).toHaveBeenCalledWith("a");
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+
+    createElementSpy.mockRestore();
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
+  });
+});

--- a/frontend/subgraph-composer/src/__tests__/erDiagramPanel.test.jsx
+++ b/frontend/subgraph-composer/src/__tests__/erDiagramPanel.test.jsx
@@ -1,0 +1,162 @@
+/**
+ * Tests for ERDiagramPanel component
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ERDiagramPanel from "../components/ERDiagramPanel.jsx";
+
+// Mock @xyflow/react to avoid canvas issues in jsdom
+jest.mock("@xyflow/react", () => {
+  const React = require("react");
+  return {
+    ReactFlow: ({ children, nodes, edges }) => (
+      <div data-testid="react-flow">
+        <div data-testid="rf-nodes">{nodes.length} nodes</div>
+        <div data-testid="rf-edges">{edges.length} edges</div>
+        {children}
+      </div>
+    ),
+    Background: () => <div data-testid="background" />,
+    Controls: () => <div data-testid="controls" />,
+    MiniMap: () => <div data-testid="minimap" />,
+    Handle: ({ position }) => <div data-testid={`handle-${position}`} />,
+    Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+    useNodesState: (initial) => {
+      const [nodes, setNodes] = React.useState(initial);
+      const onChange = React.useCallback((changes) => {
+        setNodes((prev) =>
+          prev.map((n) => {
+            const change = changes.find((c) => c.id === n.id);
+            return change ? { ...n, ...change } : n;
+          }),
+        );
+      }, []);
+      return [nodes, setNodes, onChange];
+    },
+    useEdgesState: (initial) => {
+      const [edges, setEdges] = React.useState(initial);
+      const onChange = React.useCallback((changes) => {
+        setEdges((prev) =>
+          prev.map((e) => {
+            const change = changes.find((c) => c.id === e.id);
+            return change ? { ...e, ...change } : e;
+          }),
+        );
+      }, []);
+      return [edges, setEdges, onChange];
+    },
+    MarkerType: { ArrowClosed: "arrowclosed" },
+  };
+});
+
+jest.mock("../components/ERDiagramNode.jsx", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({ data }) => <div data-testid="entity-node">{data.label}</div>,
+  };
+});
+
+const sampleSDL = `
+  type Product @key(fields: "id") {
+    id: ID!
+    name: String
+    reviews: [Review]
+  }
+
+  type Review {
+    id: ID!
+    rating: Int
+  }
+`;
+
+const schemas = [
+  { id: "schema1", name: "Catalog" },
+  { id: "schema2", name: "Reviews" },
+];
+
+const typeSources = {
+  Product: ["schema1"],
+  Review: ["schema2"],
+};
+
+describe("ERDiagramPanel", () => {
+  test("renders empty state when no SDL is provided", () => {
+    render(<ERDiagramPanel supergraphSDL="" subgraphsMap={new Map()} schemas={[]} typeSources={{}} />);
+    expect(screen.getByText(/No supergraph available/i)).toBeInTheDocument();
+  });
+
+  test("renders diagram toggle buttons", () => {
+    render(
+      <ERDiagramPanel
+        supergraphSDL={sampleSDL}
+        subgraphsMap={new Map()}
+        schemas={schemas}
+        typeSources={typeSources}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^Diagram$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Mermaid$/i })).toBeInTheDocument();
+  });
+
+  test("switches to Mermaid view on click", async () => {
+    render(
+      <ERDiagramPanel
+        supergraphSDL={sampleSDL}
+        subgraphsMap={new Map()}
+        schemas={schemas}
+        typeSources={typeSources}
+      />,
+    );
+
+    const mermaidBtn = screen.getByRole("button", { name: /^Mermaid$/i });
+    fireEvent.click(mermaidBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/erDiagram/)).toBeInTheDocument();
+    });
+  });
+
+  test("renders ReactFlow when SDL is provided", () => {
+    render(
+      <ERDiagramPanel
+        supergraphSDL={sampleSDL}
+        subgraphsMap={new Map()}
+        schemas={schemas}
+        typeSources={typeSources}
+      />,
+    );
+    expect(screen.getByTestId("react-flow")).toBeInTheDocument();
+  });
+
+  test("shows export button when data is available", () => {
+    render(
+      <ERDiagramPanel
+        supergraphSDL={sampleSDL}
+        subgraphsMap={new Map()}
+        schemas={schemas}
+        typeSources={typeSources}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Export Mermaid/i })).toBeInTheDocument();
+  });
+
+  test("hides export button when no data is available", () => {
+    render(<ERDiagramPanel supergraphSDL="" subgraphsMap={new Map()} schemas={[]} typeSources={{}} />);
+    expect(screen.queryByRole("button", { name: /Export Mermaid/i })).not.toBeInTheDocument();
+  });
+
+  test("renders swimlane legend when subgraphs exist", () => {
+    render(
+      <ERDiagramPanel
+        supergraphSDL={sampleSDL}
+        subgraphsMap={new Map()}
+        schemas={schemas}
+        typeSources={typeSources}
+      />,
+    );
+    expect(screen.getByText("Catalog")).toBeInTheDocument();
+    expect(screen.getByText("Reviews")).toBeInTheDocument();
+  });
+});

--- a/frontend/subgraph-composer/src/components/ERDiagramNode.css
+++ b/frontend/subgraph-composer/src/components/ERDiagramNode.css
@@ -1,0 +1,118 @@
+.er-node {
+  background: white;
+  border: 2px solid #ccc;
+  border-radius: var(--radius-md, 8px);
+  min-width: 200px;
+  max-width: 280px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 0.85rem;
+  color: var(--color-text, #1f2937);
+  overflow: hidden;
+}
+
+.er-node-header {
+  padding: 0.5rem 0.75rem;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.er-node-title {
+  font-weight: 700;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.er-node-directives {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.er-node-body {
+  padding: 0.5rem 0.75rem;
+  background: white;
+}
+
+.er-node-fields {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.er-node-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.er-node-field:last-child {
+  border-bottom: none;
+}
+
+.field-name {
+  font-weight: 600;
+  color: var(--color-text, #1f2937);
+}
+
+.field-type {
+  color: var(--color-text-light, #6b7280);
+  font-size: 0.8rem;
+  font-family: "SFMono-Regular", Consolas, monospace;
+}
+
+.field-badges {
+  display: flex;
+  gap: 0.2rem;
+  margin-left: auto;
+}
+
+.directive-badge {
+  display: inline-block;
+  padding: 0.1rem 0.35rem;
+  border-radius: 999px;
+  color: white;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.er-node-empty {
+  color: var(--color-text-light, #6b7280);
+  font-style: italic;
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 0.5rem 0;
+}
+
+.er-node-footer {
+  padding: 0.35rem 0.75rem;
+  background: var(--color-bg-secondary, #f3f4f6);
+  border-top: 1px solid #e5e7eb;
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  color: var(--color-text-light, #6b7280);
+}
+
+.er-node-source {
+  background: white;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid #e5e7eb;
+}

--- a/frontend/subgraph-composer/src/components/ERDiagramNode.css
+++ b/frontend/subgraph-composer/src/components/ERDiagramNode.css
@@ -61,6 +61,15 @@
   border-bottom: none;
 }
 
+.external-field {
+  opacity: 0.6;
+  border-bottom: 1px dashed #ccc;
+}
+
+.external-field:last-child {
+  border-bottom: 1px dashed #ccc;
+}
+
 .field-name {
   font-weight: 600;
   color: var(--color-text, #1f2937);

--- a/frontend/subgraph-composer/src/components/ERDiagramNode.jsx
+++ b/frontend/subgraph-composer/src/components/ERDiagramNode.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Handle, Position } from "@xyflow/react";
+import "./ERDiagramNode.css";
+
+const BADGE_COLORS = {
+  "@key": "#2196f3",
+  "@external": "#ff9800",
+  "@provides": "#4caf50",
+  "@requires": "#f44336",
+  "@shareable": "#9c27b0",
+  "@extends": "#795548",
+  "@override": "#e91e63",
+};
+
+function DirectiveBadge({ name }) {
+  const color = BADGE_COLORS[name] || "#607d8b";
+  return (
+    <span className="directive-badge" style={{ backgroundColor: color }} title={name}>
+      {name.replace("@", "")}
+    </span>
+  );
+}
+
+export default function ERDiagramNode({ data }) {
+  const { label, fields, directives, color, sourceNames } = data;
+
+  return (
+    <div className="er-node" style={{ borderColor: color }}>
+      <Handle type="target" position={Position.Top} style={{ background: color }} />
+      <div className="er-node-header" style={{ backgroundColor: color }}>
+        <div className="er-node-title">{label}</div>
+        {directives && directives.length > 0 && (
+          <div className="er-node-directives">
+            {directives.map((d, i) => (
+              <DirectiveBadge key={i} name={d.name} />
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="er-node-body">
+        {fields && fields.length > 0 ? (
+          <ul className="er-node-fields">
+            {fields.map((field, idx) => (
+              <li key={idx} className="er-node-field">
+                <span className="field-name">{field.name}</span>
+                <span className="field-type">{field.type}</span>
+                {field.directives && field.directives.length > 0 && (
+                  <span className="field-badges">
+                    {field.directives.map((d, i) => (
+                      <DirectiveBadge key={i} name={d.name} />
+                    ))}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="er-node-empty">No fields</div>
+        )}
+      </div>
+      {sourceNames && sourceNames.length > 0 && (
+        <div className="er-node-footer">
+          {sourceNames.map((name, i) => (
+            <span key={i} className="er-node-source">
+              {name}
+            </span>
+          ))}
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} style={{ background: color }} />
+    </div>
+  );
+}

--- a/frontend/subgraph-composer/src/components/ERDiagramNode.jsx
+++ b/frontend/subgraph-composer/src/components/ERDiagramNode.jsx
@@ -40,19 +40,22 @@ export default function ERDiagramNode({ data }) {
       <div className="er-node-body">
         {fields && fields.length > 0 ? (
           <ul className="er-node-fields">
-            {fields.map((field, idx) => (
-              <li key={idx} className="er-node-field">
-                <span className="field-name">{field.name}</span>
-                <span className="field-type">{field.type}</span>
-                {field.directives && field.directives.length > 0 && (
-                  <span className="field-badges">
-                    {field.directives.map((d, i) => (
-                      <DirectiveBadge key={i} name={d.name} />
-                    ))}
-                  </span>
-                )}
-              </li>
-            ))}
+            {fields.map((field, idx) => {
+              const isExternal = field.directives?.some((d) => d.name === "@external");
+              return (
+                <li key={idx} className={`er-node-field ${isExternal ? "external-field" : ""}`}>
+                  <span className="field-name">{field.name}</span>
+                  <span className="field-type">{field.type}</span>
+                  {field.directives && field.directives.length > 0 && (
+                    <span className="field-badges">
+                      {field.directives.map((d, i) => (
+                        <DirectiveBadge key={i} name={d.name} />
+                      ))}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         ) : (
           <div className="er-node-empty">No fields</div>

--- a/frontend/subgraph-composer/src/components/ERDiagramPanel.css
+++ b/frontend/subgraph-composer/src/components/ERDiagramPanel.css
@@ -1,0 +1,160 @@
+.er-diagram-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: white;
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0,0,0,0.05));
+  border: 1px solid var(--color-border, #d1d5db);
+  overflow: hidden;
+}
+
+.er-diagram-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
+  background: var(--color-bg-secondary, #f3f4f6);
+  border-bottom: 1px solid var(--color-border, #d1d5db);
+  flex-shrink: 0;
+  gap: var(--spacing-md, 1rem);
+}
+
+.er-diagram-toggle-group {
+  display: flex;
+  gap: 0;
+  border-radius: var(--radius-sm, 4px);
+  overflow: hidden;
+  border: 1px solid var(--color-border, #d1d5db);
+}
+
+.er-diagram-toggle-btn {
+  padding: var(--spacing-xs, 0.25rem) var(--spacing-md, 1rem);
+  border: none;
+  background: white;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--color-text, #1f2937);
+  transition: background 0.2s ease;
+}
+
+.er-diagram-toggle-btn:hover {
+  background: var(--color-bg, #f9fafb);
+}
+
+.er-diagram-toggle-btn.active {
+  background: var(--color-primary, #6366f1);
+  color: white;
+  font-weight: 600;
+}
+
+.er-diagram-export-btn {
+  padding: var(--spacing-xs, 0.25rem) var(--spacing-md, 1rem);
+  border: 1px solid var(--color-border, #d1d5db);
+  background: white;
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--color-text, #1f2937);
+  transition: all 0.2s ease;
+}
+
+.er-diagram-export-btn:hover {
+  background: var(--color-bg-secondary, #f3f4f6);
+  border-color: var(--color-text-light, #6b7280);
+}
+
+.er-diagram-viewport {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.er-diagram-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--color-text-light, #6b7280);
+  font-size: 0.95rem;
+  gap: var(--spacing-md, 1rem);
+}
+
+.er-diagram-mermaid {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: var(--spacing-md, 1rem);
+  gap: var(--spacing-md, 1rem);
+  overflow: auto;
+}
+
+.er-diagram-mermaid-code {
+  flex: 1;
+  background: var(--color-bg-secondary, #f3f4f6);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: var(--radius-md, 8px);
+  padding: var(--spacing-md, 1rem);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow: auto;
+  white-space: pre;
+  margin: 0;
+}
+
+.er-diagram-copy-btn {
+  align-self: flex-start;
+  padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
+  border: 1px solid var(--color-border, #d1d5db);
+  background: white;
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--color-text, #1f2937);
+  transition: all 0.2s ease;
+}
+
+.er-diagram-copy-btn:hover {
+  background: var(--color-bg-secondary, #f3f4f6);
+}
+
+.er-swimlanes-legend {
+  position: absolute;
+  top: var(--spacing-sm, 0.5rem);
+  right: var(--spacing-sm, 0.5rem);
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: var(--radius-sm, 4px);
+  padding: var(--spacing-sm, 0.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  font-size: 0.8rem;
+}
+
+.er-swimlanes-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.er-swimlanes-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.er-swimlanes-name {
+  color: var(--color-text, #1f2937);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 140px;
+}

--- a/frontend/subgraph-composer/src/components/ERDiagramPanel.css
+++ b/frontend/subgraph-composer/src/components/ERDiagramPanel.css
@@ -135,12 +135,14 @@
   gap: 0.4rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
   font-size: 0.8rem;
+  pointer-events: none;
 }
 
 .er-swimlanes-item {
   display: flex;
   align-items: center;
   gap: 0.4rem;
+  pointer-events: auto;
 }
 
 .er-swimlanes-dot {

--- a/frontend/subgraph-composer/src/components/ERDiagramPanel.jsx
+++ b/frontend/subgraph-composer/src/components/ERDiagramPanel.jsx
@@ -17,7 +17,7 @@ const nodeTypes = {
   entityNode: ERDiagramNode,
 };
 
-export default function ERDiagramPanel({ supergraphSDL, subgraphsMap, schemas, typeSources }) {
+export default function ERDiagramPanel({ supergraphSDL, schemas, typeSources }) {
   const [viewMode, setViewMode] = useState("diagram"); // "diagram" | "mermaid"
   const [mermaidText, setMermaidText] = useState("");
   const [nodes, setNodes, onNodesChange] = useNodesState([]);

--- a/frontend/subgraph-composer/src/components/ERDiagramPanel.jsx
+++ b/frontend/subgraph-composer/src/components/ERDiagramPanel.jsx
@@ -1,0 +1,144 @@
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  MarkerType,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import "./ERDiagramPanel.css";
+import { parseERDiagram, generateMermaidER, exportMermaidER } from "../lib/erDiagramParser.js";
+import ERDiagramNode from "./ERDiagramNode.jsx";
+
+const nodeTypes = {
+  entityNode: ERDiagramNode,
+};
+
+export default function ERDiagramPanel({ supergraphSDL, subgraphsMap, schemas, typeSources }) {
+  const [viewMode, setViewMode] = useState("diagram"); // "diagram" | "mermaid"
+  const [mermaidText, setMermaidText] = useState("");
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+
+  const erData = useMemo(() => {
+    if (!supergraphSDL) return { nodes: [], edges: [], subgraphs: [] };
+    return parseERDiagram(supergraphSDL, typeSources, schemas);
+  }, [supergraphSDL, typeSources, schemas]);
+
+  useEffect(() => {
+    if (erData.nodes.length > 0) {
+      setNodes(erData.nodes);
+      setEdges(
+        erData.edges.map((e) => ({
+          ...e,
+          markerEnd: e.markerEnd
+            ? { type: MarkerType.ArrowClosed, width: 12, height: 12, color: e.style?.stroke || "#999" }
+            : undefined,
+          markerStart: e.markerStart
+            ? { type: MarkerType.ArrowClosed, width: 12, height: 12, color: e.style?.stroke || "#999" }
+            : undefined,
+        })),
+      );
+      const mermaid = generateMermaidER(erData);
+      setMermaidText(mermaid);
+    } else {
+      setNodes([]);
+      setEdges([]);
+      setMermaidText("");
+    }
+  }, [erData, setNodes, setEdges]);
+
+  const handleExport = useCallback(() => {
+    exportMermaidER(erData, "federation-er-diagram.mmd");
+  }, [erData]);
+
+  const hasData = erData.nodes.length > 0;
+
+  return (
+    <div className="er-diagram-panel">
+      <div className="er-diagram-toolbar">
+        <div className="er-diagram-toggle-group">
+          <button
+            className={`er-diagram-toggle-btn ${viewMode === "diagram" ? "active" : ""}`}
+            onClick={() => setViewMode("diagram")}
+            title="Show interactive ER diagram"
+          >
+            Diagram
+          </button>
+          <button
+            className={`er-diagram-toggle-btn ${viewMode === "mermaid" ? "active" : ""}`}
+            onClick={() => setViewMode("mermaid")}
+            title="Show Mermaid source"
+          >
+            Mermaid
+          </button>
+        </div>
+
+        {hasData && (
+          <button className="er-diagram-export-btn" onClick={handleExport} title="Export Mermaid ER diagram">
+            Export Mermaid
+          </button>
+        )}
+      </div>
+
+      <div className="er-diagram-viewport">
+        {viewMode === "diagram" ? (
+          hasData ? (
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              nodeTypes={nodeTypes}
+              fitView
+              attributionPosition="bottom-right"
+            >
+              <Background variant="dots" gap={12} size={1} />
+              <Controls />
+              <MiniMap nodeStrokeWidth={3} zoomable pannable />
+              {/* Subgraph swimlanes overlay */}
+              <SubgraphSwimlanes subgraphs={erData.subgraphs} />
+            </ReactFlow>
+          ) : (
+            <div className="er-diagram-empty">
+              <p>No supergraph available. Generate subgraphs first.</p>
+            </div>
+          )
+        ) : (
+          <div className="er-diagram-mermaid">
+            {mermaidText ? (
+              <>
+                <pre className="er-diagram-mermaid-code">{mermaidText}</pre>
+                <button className="er-diagram-copy-btn" onClick={() => navigator.clipboard?.writeText(mermaidText)}>
+                  Copy to Clipboard
+                </button>
+              </>
+            ) : (
+              <div className="er-diagram-empty">
+                <p>No supergraph available. Generate subgraphs first.</p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SubgraphSwimlanes({ subgraphs }) {
+  if (!subgraphs || subgraphs.length === 0) return null;
+
+  return (
+    <div className="er-swimlanes-legend">
+      {subgraphs.map((sg) => (
+        <div key={sg.id} className="er-swimlanes-item">
+          <span className="er-swimlanes-dot" style={{ backgroundColor: sg.color }} />
+          <span className="er-swimlanes-name">{sg.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/subgraph-composer/src/hooks/useComposition.js
+++ b/frontend/subgraph-composer/src/hooks/useComposition.js
@@ -6,12 +6,14 @@ export function useComposition() {
   const [supergraphSDL, setSupergraphSDL] = useState("");
   const [compositionStats, setCompositionStats] = useState(null);
   const [compositionErrors, setCompositionErrors] = useState([]);
+  const [typeSources, setTypeSources] = useState({});
 
   const compose = useCallback(async (subgraphs) => {
     if (subgraphs.size === 0) {
       setSupergraphSDL("");
       setCompositionStats(null);
       setCompositionErrors([]);
+      setTypeSources({});
       return;
     }
 
@@ -32,11 +34,13 @@ export function useComposition() {
           setSupergraphSDL(result.sdl);
           setCompositionStats(result.stats);
           setCompositionErrors(result.errors);
+          setTypeSources(result.typeSources ?? {});
         } else {
           span.setAttribute("composition.errors", result.errors.join("; "));
           span.setStatus({ code: 2, message: result.errors[0] });
           setCompositionErrors(result.errors);
           setSupergraphSDL("");
+          setTypeSources({});
         }
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
@@ -44,6 +48,7 @@ export function useComposition() {
         span.setStatus({ code: 2, message: errorMsg });
         setCompositionErrors([errorMsg]);
         setSupergraphSDL("");
+        setTypeSources({});
       } finally {
         span.end();
       }
@@ -54,6 +59,7 @@ export function useComposition() {
     supergraphSDL,
     compositionStats,
     compositionErrors,
+    typeSources,
     compose,
   };
 }

--- a/frontend/subgraph-composer/src/lib/composer.js
+++ b/frontend/subgraph-composer/src/lib/composer.js
@@ -132,6 +132,14 @@ export function composeSupergraph(subgraphs, options = {}) {
 
     const finalSDL = sdlLines.filter(Boolean).join("\n\n");
 
+    // Build typeSources map for color-coding in visualizers
+    const typeSources = {};
+    for (const [typeName, sources] of typeSourceMap.entries()) {
+      if (typeName !== "_rootTypes") {
+        typeSources[typeName] = sources;
+      }
+    }
+
     return {
       success: errors.length === 0,
       sdl: finalSDL,
@@ -142,6 +150,7 @@ export function composeSupergraph(subgraphs, options = {}) {
         mergedTypes: Array.from(typeRegistry.values()).filter((d) => d && d.kind).length,
         conflicts: conflicts, // Return full conflict objects, not just strings
       },
+      typeSources,
     };
   } catch (error) {
     errors.push(`Composition failed: ${error.message}`);
@@ -150,6 +159,7 @@ export function composeSupergraph(subgraphs, options = {}) {
       sdl: "",
       errors,
       stats: { totalTypes: 0, totalFields: 0, mergedTypes: 0, conflicts: [] },
+      typeSources: {},
     };
   }
 }

--- a/frontend/subgraph-composer/src/lib/erDiagramParser.js
+++ b/frontend/subgraph-composer/src/lib/erDiagramParser.js
@@ -52,7 +52,7 @@ export function parseERDiagram(sdl, typeSources = {}, schemas = []) {
   // First pass: create all nodes
   const nodeMap = new Map();
   let nodeId = 0;
-  const typeRegex = /type\s+(\w+)\s*(?:@[\w(\s"=:,)]+)?\s*\{([^}]*)\}/g;
+  const typeRegex = /type\s+(\w+)(?:\s+implements\s+[\w&\s,]+)?\s*(?:@[\w(\s"=:,)]+)?\s*\{([^}]*)\}/g;
   let match;
 
   while ((match = typeRegex.exec(sdl)) !== null) {
@@ -258,7 +258,7 @@ export function generateMermaidER(erData) {
     const fields = node.data.fields || [];
     lines.push(`  ${label} {`);
     for (const field of fields) {
-      const type = field.type.replace(/!/g, "");
+      const type = extractBaseType(field.type);
       const badges = field.directives
         .filter((d) => FEDERATION_DIRECTIVES.includes(d.name))
         .map((d) => d.name)

--- a/frontend/subgraph-composer/src/lib/erDiagramParser.js
+++ b/frontend/subgraph-composer/src/lib/erDiagramParser.js
@@ -1,0 +1,313 @@
+/**
+ * ER Diagram Parser
+ *
+ * Parses GraphQL SDL into entity-relationship nodes and edges
+ * with federation directive metadata.
+ */
+
+export const FEDERATION_DIRECTIVES = ["@key", "@external", "@provides", "@requires", "@shareable", "@extends", "@override"];
+
+export const DIRECTIVE_EDGE_STYLES = {
+  "@key": { strokeDasharray: "0", markerEnd: "arrow" },
+  "@external": { strokeDasharray: "5 5", markerEnd: "arrow" },
+  "@requires": { strokeDasharray: "2 2", markerEnd: "arrow" },
+  "@shareable": { strokeDasharray: "0", markerEnd: "arrow", markerStart: "arrow" },
+  "@provides": { strokeDasharray: "0", markerEnd: "arrow", strokeWidth: 2 },
+  "@extends": { strokeDasharray: "8 4", markerEnd: "arrow" },
+  "@override": { strokeDasharray: "0", markerEnd: "arrow", strokeWidth: 2 },
+};
+
+export const SUBGRAPH_COLORS = [
+  "#2196f3",
+  "#4caf50",
+  "#ff9800",
+  "#9c27b0",
+  "#f44336",
+  "#009688",
+  "#795548",
+  "#607d8b",
+  "#e91e63",
+  "#3f51b5",
+];
+
+/**
+ * Parse GraphQL SDL into entity nodes
+ * @param {string} sdl - GraphQL SDL
+ * @param {Object} typeSources - Map of typeName -> [schemaId]
+ * @param {Array<{id: string, name: string}>} schemas - Schema metadata
+ * @returns {{nodes: Array, edges: Array, subgraphs: Array}}
+ */
+export function parseERDiagram(sdl, typeSources = {}, schemas = []) {
+  if (!sdl || typeof sdl !== "string") {
+    return { nodes: [], edges: [], subgraphs: [] };
+  }
+
+  const schemaIndexMap = new Map();
+  schemas.forEach((s, idx) => schemaIndexMap.set(s.id, idx));
+
+  const nodes = [];
+  const edges = [];
+  const subgraphGroups = new Map();
+
+  // First pass: create all nodes
+  const nodeMap = new Map();
+  let nodeId = 0;
+  const typeRegex = /type\s+(\w+)\s*(?:@[\w(\s"=:,)]+)?\s*\{([^}]*)\}/g;
+  let match;
+
+  while ((match = typeRegex.exec(sdl)) !== null) {
+    const typeName = match[1];
+    const body = match[2];
+    const fullMatch = match[0];
+
+    const typeDirectives = extractDirectives(fullMatch.substring(0, fullMatch.indexOf("{")));
+    const fields = parseFields(body);
+
+    const sourceIds = typeSources[typeName] || [];
+    const sourceIndices = sourceIds.map((id) => schemaIndexMap.get(id) ?? 0);
+    const primaryColor = SUBGRAPH_COLORS[sourceIndices[0] ?? 0];
+
+    const node = {
+      id: `node-${nodeId++}`,
+      type: "entityNode",
+      position: { x: 0, y: 0 },
+      data: {
+        label: typeName,
+        fields,
+        directives: typeDirectives,
+        color: primaryColor,
+        sourceIds,
+        sourceNames: sourceIds.map((id) => schemas.find((s) => s.id === id)?.name || id),
+      },
+    };
+
+    nodes.push(node);
+    nodeMap.set(typeName, node);
+
+    for (const sourceId of sourceIds) {
+      if (!subgraphGroups.has(sourceId)) {
+        subgraphGroups.set(sourceId, {
+          id: sourceId,
+          name: schemas.find((s) => s.id === sourceId)?.name || sourceId,
+          color: SUBGRAPH_COLORS[schemaIndexMap.get(sourceId) ?? 0],
+          nodeIds: [],
+        });
+      }
+      subgraphGroups.get(sourceId).nodeIds.push(node.id);
+    }
+  }
+
+  // Second pass: create edges from all nodes
+  for (const node of nodes) {
+    for (const field of node.data.fields) {
+      const baseType = extractBaseType(field.type);
+      if (baseType && baseType !== node.data.label && isComplexType(baseType)) {
+        const targetNode = nodeMap.get(baseType);
+        if (targetNode) {
+          const edgeDirectives = field.directives.filter((d) => FEDERATION_DIRECTIVES.includes(d.name));
+          const primaryDirective = edgeDirectives[0]?.name || "@key";
+          const style = DIRECTIVE_EDGE_STYLES[primaryDirective] || DIRECTIVE_EDGE_STYLES["@key"];
+
+          edges.push({
+            id: `edge-${node.id}-${targetNode.id}-${field.name}`,
+            source: node.id,
+            target: targetNode.id,
+            label: field.name,
+            style: {
+              stroke: node.data.color,
+              strokeWidth: style.strokeWidth || 1,
+              strokeDasharray: style.strokeDasharray,
+            },
+            markerEnd: style.markerEnd,
+            markerStart: style.markerStart,
+            data: {
+              directives: edgeDirectives,
+              fieldName: field.name,
+            },
+          });
+        }
+      }
+    }
+  }
+
+  // Apply a simple layout: distribute nodes in columns per subgraph
+  const subgraphs = Array.from(subgraphGroups.values());
+  layoutNodes(nodes, subgraphs);
+
+  return { nodes, edges, subgraphs };
+}
+
+/**
+ * Extract fields and their directives from a type body
+ */
+function parseFields(body) {
+  const fields = [];
+  const lines = body.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    // Match field definitions: name(args): Type @directives
+    const fieldMatch = trimmed.match(/^(\w+)(?:\s*\([^)]*\))?\s*:\s*([^@\n]+)(.*)?$/);
+    if (fieldMatch) {
+      const fieldName = fieldMatch[1];
+      const typeStr = fieldMatch[2].trim();
+      const directiveStr = fieldMatch[3] || "";
+
+      const directives = extractDirectives(directiveStr);
+      fields.push({
+        name: fieldName,
+        type: typeStr,
+        directives,
+      });
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Extract directives from a string
+ */
+function extractDirectives(str) {
+  const directives = [];
+  if (!str) return directives;
+
+  const directiveRegex = /@(\w+)(?:\s*\(\s*([^)]*)\s*\))?/g;
+  let dmatch;
+
+  while ((dmatch = directiveRegex.exec(str)) !== null) {
+    const name = `@${dmatch[1]}`;
+    const args = dmatch[2] || "";
+    directives.push({ name, args });
+  }
+
+  return directives;
+}
+
+/**
+ * Extract base type from GraphQL type string
+ */
+function extractBaseType(typeStr) {
+  return (typeStr || "").replace(/[!\[\]]/g, "").trim();
+}
+
+/**
+ * Check if a type is a complex (non-scalar) type
+ */
+function isComplexType(typeStr) {
+  const base = extractBaseType(typeStr);
+  const scalars = ["String", "Int", "Float", "Boolean", "ID", "Date", "DateTime", "JSON", "Url", "Email"];
+  return base && !scalars.includes(base);
+}
+
+/**
+ * Simple layout: place nodes in columns per subgraph swimlane
+ */
+function layoutNodes(nodes, subgraphs) {
+  const laneWidth = 320;
+  const nodeHeight = 120;
+  const nodeSpacing = 40;
+
+  const nodePositions = new Map();
+
+  subgraphs.forEach((subgraph, laneIndex) => {
+    let yOffset = 0;
+    for (const nodeId of subgraph.nodeIds) {
+      if (!nodePositions.has(nodeId)) {
+        nodePositions.set(nodeId, {
+          x: laneIndex * laneWidth + 20,
+          y: yOffset,
+        });
+        yOffset += nodeHeight + nodeSpacing;
+      } else {
+        // Node belongs to multiple subgraphs; center it between lanes
+        const existing = nodePositions.get(nodeId);
+        const newX = laneIndex * laneWidth + 20;
+        nodePositions.set(nodeId, {
+          x: (existing.x + newX) / 2,
+          y: existing.y,
+        });
+      }
+    }
+  });
+
+  for (const node of nodes) {
+    const pos = nodePositions.get(node.id);
+    if (pos) {
+      node.position = pos;
+    }
+  }
+}
+
+/**
+ * Generate a Mermaid ER diagram string from parsed ER data
+ * @param {{nodes: Array, edges: Array, subgraphs: Array}} erData
+ * @returns {string}
+ */
+export function generateMermaidER(erData) {
+  const { nodes, edges, subgraphs } = erData;
+  if (!nodes || nodes.length === 0) return "";
+
+  const lines = ["erDiagram"];
+
+  // Define entities
+  for (const node of nodes) {
+    const label = node.data.label;
+    const fields = node.data.fields || [];
+    lines.push(`  ${label} {`);
+    for (const field of fields) {
+      const type = field.type.replace(/!/g, "");
+      const badges = field.directives
+        .filter((d) => FEDERATION_DIRECTIVES.includes(d.name))
+        .map((d) => d.name)
+        .join(" ");
+      const badgeStr = badges ? ` ${badges}` : "";
+      lines.push(`    ${type} ${field.name}${badgeStr}`);
+    }
+    lines.push("  }");
+  }
+
+  // Define relationships
+  const relationMap = new Map();
+  for (const edge of edges) {
+    const sourceLabel = nodes.find((n) => n.id === edge.source)?.data.label;
+    const targetLabel = nodes.find((n) => n.id === edge.target)?.data.label;
+    if (!sourceLabel || !targetLabel) continue;
+
+    const key = `${sourceLabel} ||--|| ${targetLabel}`;
+    const directives = edge.data?.directives?.map((d) => d.name).join(", ") || "";
+    const label = edge.label || "";
+    const fullLabel = directives ? `${label} : ${directives}` : label;
+
+    if (!relationMap.has(key)) {
+      relationMap.set(key, fullLabel);
+    }
+  }
+
+  for (const [key, label] of relationMap.entries()) {
+    lines.push(`  ${key} : "${label}"`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Export Mermaid ER diagram as a downloadable file
+ */
+export function exportMermaidER(erData, filename = "er-diagram.mmd") {
+  const mermaid = generateMermaidER(erData);
+  const blob = new Blob([mermaid], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+
+  return mermaid;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
       '@visual-json/react':
         specifier: workspace:*
         version: link:../../external/visual-json/packages/@visual-json/react
+      '@xyflow/react':
+        specifier: ^12.11.0
+        version: 12.11.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql:
         specifier: ^16.14.0
         version: 16.14.0
@@ -3734,6 +3737,22 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  '@xyflow/react@12.11.0':
+    resolution: {integrity: sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.77':
+    resolution: {integrity: sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==}
+
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
@@ -4151,6 +4170,9 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -8461,6 +8483,21 @@ packages:
   zone.js@0.15.1:
     resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -12450,6 +12487,31 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  '@xyflow/react@12.11.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@xyflow/system': 0.0.77
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@19.2.14)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.77':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abab@2.0.6: {}
 
   acorn-globals@7.0.1:
@@ -12912,6 +12974,8 @@ snapshots:
   ci-info@3.9.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  classcat@5.0.5: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -18132,6 +18196,10 @@ snapshots:
 
   urlpattern-polyfill@8.0.2: {}
 
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -18524,5 +18592,12 @@ snapshots:
   zod@3.25.76: {}
 
   zone.js@0.15.1: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 18.3.1
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
# feat(frontend): add federation ER diagram visualization to subgraph-composer

**Branch:** `feat/20-federation-er-diagram`
**Base:** `main`

## Summary

Adds a custom entity-relationship diagram visualization for Apollo Federation concepts using `@xyflow/react`.

## Changes

- **New `ERDiagramPanel` component** (`frontend/subgraph-composer/src/components/ERDiagramPanel.jsx`)
  - React Flow canvas with subgraph swimlanes
  - Entity cards with federation directive badges
  - Relationship edges styled by directive type
  - Mermaid ER diagram export
- **New `ERDiagramNode` component** (`frontend/subgraph-composer/src/components/ERDiagramNode.jsx`)
  - Custom node type with field list and badge styling
  - Color-coded headers by subgraph origin
  - `@external` fields styled with dashed border and reduced opacity
- **New `erDiagramParser.js`** (`frontend/subgraph-composer/src/lib/erDiagramParser.js`)
  - Parses GraphQL SDL into nodes/edges with federation metadata
  - Handles `type implements` syntax
  - Generates Mermaid ER syntax for static export
  - Two-pass layout for subgraph swimlanes
- **Third tab** in `App.jsx`: Preview / Visualize / ER Diagram
- **Lazy loading** of ERDiagramPanel to avoid bundling `@xyflow/react` on initial render
- **Tests**: `erDiagram.test.js` (parser tests) and `erDiagramPanel.test.jsx` (component tests)

## Verification

- `pnpm test` in `frontend/subgraph-composer` → 188 tests pass
- `pnpm build` → builds successfully (ERDiagramPanel chunk ~185KB, lazy-loaded)

## Review Notes

- Reviewer identified and fixed: parser `implements` support, Mermaid array bracket stripping, `@external` styling, swimlane legend pointer-events, unused prop cleanup.
- Remaining items for follow-up: docs page for ER analogy, static Mermaid pipeline, `@key` cross-subgraph arrows as explicit FK edges.

## Related

- Closes #20
- ADR 0010: `docs/adr/0010-visual-editor-design.md`
- Related: #19 (graphql-voyager) — both PRs should be merged together; App.jsx will need conflict resolution to include both tabs.
