### PR TITLE
docs: add ADRs for federation visualization, authorization, and caching

### DIFF
--- a/docs/adr/0010-visual-editor-design.md
+++ b/docs/adr/0010-visual-editor-design.md
@@ -1,0 +1,109 @@
+# 0010: Visual Editor Design for Federated Subgraph ERD
+
+Date: 2026-06-05
+
+## Status
+
+Accepted
+
+## Context
+
+As the `json-schema-x-graphql` subgraph composer grows, users need a visual way to understand:
+- Which types belong to which subgraph
+- How cross-subgraph entity references (`@key`, `@external`) connect
+- How federation directives (`@provides`, `@requires`, `@shareable`) affect data flow
+
+The challenge is finding the "sweet spot" between a powerful, explicit view (where developers can edit and resolve data links) and a streamlined, decluttered view (where navigating a massive enterprise supergraph doesn't overwhelm cognition).
+
+## Decision
+
+Adopt a **dual-visualization strategy** for the subgraph composer:
+
+1. **graphql-voyager integration** (Issue #19) — immediate, interactive force-directed graph view of any introspection result
+2. **Custom ER diagram view** (Issue #20) — domain-specific notation that maps federation concepts to familiar database/ORM entity-relationship concepts
+
+### Visual Design System
+
+#### 1. Subgraph Domain Boundaries
+- **Dashed bounding boxes with semi-transparent background shading** for each subgraph
+- Entities owned by a domain live inside its zone
+- Extending domains show "proxy nodes" of entities owned elsewhere
+- Inspiration: RAG architecture diagrams that separate functional domains without boxing in data flow
+
+#### 2. Entity and Field Representation
+- Structured card/table nodes with solid-color header matching the owning domain
+- Field names aligned left, data types as muted text right
+- Collapsible node structures to reduce noise
+
+#### 3. Directive Badges
+Replace verbose text directives with interactive visual badges:
+- **`@key`**: Gold key icon (primary identifier)
+- **`@external`**: Hollow dashed-outline pill (borrowed field)
+- **`@requires` & `@provides`**: Brightly colored pills (purple and green) on dark mode
+- **Hover states** reveal underlying arguments for dynamic editing
+
+#### 4. Dynamic Linkages
+- **Smooth Bezier curves** connecting specific fields across nodes (not just table-to-table)
+- **Solid arrow** = `@key` reference (owns/defines)
+- **Dashed arrow** = `@external` reference (borrows/depends)
+- **Double-headed arrow** = `@shareable` (multiple owners)
+- **Dotted arrow with label** = `@requires` dependency
+
+### Elements to Include vs. Exclude
+
+**INCLUDE (explicit control):**
+1. Field-level edge routing (drag lines from `@requires` to `@external`)
+2. Interactive directive badges with hover states
+3. Cross-domain color slivers on primary entity cards (show which subgraphs extend it)
+4. Real-time composition validation indicators (red error highlights on invalid edges)
+
+**EXCLUDE (streamlined UI):**
+1. Verbose scalar type definitions by default (hide `String`, `Int`, `Boolean` unless clicked)
+2. Boilerplate/implicit directives (`@shareable` by default, `x-graphql-field-name` extensions)
+3. "Spaghetti" cross-domain wiring (collapse into thick domain-to-domain pipelines by default; expand on click)
+4. Underlying data source mapping (don't show REST endpoints or DB tables on the ERD canvas)
+
+## Consequences
+
+### Positive
+- **Immediate readability**: Database-minded developers understand federation through familiar ER concepts
+- **Progressive disclosure**: Power users get field-level editing; casual users see clean domain boundaries
+- **Consistent with x-graphql metadata**: The `x-graphql-federation` JSON Schema key already carries all required metadata
+- **Two implementations share one design**: Both voyager and ER views use the same color system and subgraph metadata
+
+### Negative
+- **Two implementations to maintain**: Both voyager and custom ER view require ongoing maintenance
+- **React Flow bundle size**: Custom ER view adds `@xyflow/react` dependency
+- **Color system must stay stable**: Changing subgraph colors breaks user's mental model
+
+### Tradeoffs
+- **Mermaid for docs**: Static `erDiagram` blocks generated from SDL for documentation pages (zero JS dependency)
+- **React Flow for interactive UI**: Embedded directly in `frontend/subgraph-composer` as a second visualizer tab
+
+## Implementation Strategy
+
+### Phase 1: graphql-voyager (Issue #19) — Completed
+- Add `graphql-voyager` as lazy-loaded dependency
+- Feed composed supergraph SDL through `sdlToSchema` → `<Voyager>`
+- Toggle between Supergraph and Per-Subgraph views
+- Subgraph color-coding via injected CSS overrides
+
+### Phase 2: Custom ER Diagram (Issue #20) — Pending
+- Add `@xyflow/react` to subgraph-composer
+- Define `EntityCard` node type with PK/FK badges
+- Implement subgraph swimlanes
+- Generate Mermaid `erDiagram` blocks for docs
+
+### Phase 3: Unified Design Polish
+- Normalize color palette between voyager and ER views
+- Add composition validation highlights to both views
+- Cross-domain sliver indicators on entity cards
+
+## References
+
+- Issue #19: `feat(editor): supergraph/subgraph visualization with graphql-voyager`
+- Issue #20: `feat(editor): x-graphql federation concepts as ER/entity-relationship diagram`
+- Issue #85: `Visual Editor Design Guide` (superseded by this ADR)
+- React Flow: https://reactflow.dev/
+- Mermaid ER docs: https://mermaid.js.org/syntax/entityRelationshipDiagram.html
+- graphql-voyager: https://github.com/APIs-guru/graphql-voyager

--- a/docs/adr/0011-fine-grained-authorization.md
+++ b/docs/adr/0011-fine-grained-authorization.md
@@ -1,0 +1,97 @@
+# 0011: Fine-Grained Authorization via @policy Directive and OpenFGA
+
+Date: 2026-06-05
+
+## Status
+
+Accepted
+
+## Context
+
+The `json-schema-x-graphql` converter already supports Apollo Federation v2.9 authorization directives (`@authenticated`, `@requiresScopes`, `@policy`). In enterprise deployments, teams need caller-based, relationship-based access control (ReBAC) that goes beyond simple role lists. OpenFGA is a CNCF incubating project that provides fine-grained authorization based on the Zanzibar model.
+
+The question is: how do we bridge the gap between the `@policy` directive in GraphQL SDL and an external policy engine like OpenFGA without bloating subgraphs or breaking the "subgraph independence" principle?
+
+## Decision
+
+Adopt a **three-layer authorization architecture**:
+
+### Layer 1: Schema Declaration (Subgraph)
+Subgraphs declare policy requirements via `x-graphql-*` vendor extensions in JSON Schema, which the converter losslessly translates into GraphQL `@policy` directives.
+
+```json
+{
+  "properties": {
+    "document": {
+      "type": "object",
+      "x-graphql-policy": "viewer_can_read_document"
+    }
+  }
+}
+```
+
+Becomes:
+
+```graphql
+type Document @policy("viewer_can_read_document") {
+  content: String
+}
+```
+
+**Principle:** Subgraphs are lightweight and autonomous. They declare the policy requirement but do not implement the policy logic.
+
+### Layer 2: Router Enforcement (Control Plane)
+The federated router acts as the centralized enforcement point:
+1. Extracts caller identity (e.g., JWT) from the incoming request
+2. Intercepts any field or entity tagged with `@policy`
+3. Evaluates the policy against the external policy engine (OpenFGA) before orchestrating execution
+4. Rejects unauthorized fields at the query-planning stage, before subgraphs are even contacted
+
+**Principle:** The router centralizes complex, dynamic authorization logic at runtime. This mirrors how enterprise data federation tools integrate with Apache Ranger for centralized policy management.
+
+### Layer 3: Policy Engine (OpenFGA)
+- Stores authorization tuples (user, relation, object)
+- Provides Check, ListObjects, and Expand APIs
+- Managed independently of the GraphQL schema lifecycle
+
+## Consequences
+
+### Positive
+- **Subgraph autonomy preserved**: Subgraphs don't need to know about OpenFGA or complex RBAC
+- **Centralized governance**: Policy changes happen in one place (the router + policy engine), not across N subgraphs
+- **Lossless conversion**: `x-graphql-policy` maps directly to `@policy` without schema changes
+- **Federation-native**: Uses the standard Apollo Federation v2.9 `@policy` directive
+
+### Negative
+- **Router complexity**: The router must be extended with a policy evaluation plugin
+- **Cold-path latency**: Every `@policy` field requires a round-trip to the policy engine (mitigated by caching)
+- **Policy drift**: If the JSON Schema's `x-graphql-policy` values diverge from the OpenFGA model, authorization failures become silent denials
+
+### Mitigation
+- Provide a `policy` CLI command that validates `x-graphql-policy` values against a registered OpenFGA model
+- Cache policy checks in the router with TTL-based invalidation
+- Add composition validation that flags `@policy` directives without matching OpenFGA relations
+
+## Implementation Strategy
+
+### Phase 1: Converter Support (Completed)
+- `@policy` directive is already implemented in the converter (commit `f414f51`)
+- `x-graphql-policy` vendor extension is supported in the schema
+
+### Phase 2: Router Plugin (Pending)
+- Implement a router plugin that intercepts `@policy` fields
+- Add OpenFGA client configuration (endpoint, store ID, model ID)
+- Cache policy check results in Redis/memory
+
+### Phase 3: Validation & Tooling (Pending)
+- CLI command: `json-schema-x-graphql validate-policies --openfga-url ...`
+- Composition rule: all `@policy` values must exist in the OpenFGA model
+- Docs page explaining the three-layer architecture
+
+## References
+
+- Issue #83: `Map security federation directives to Fine Grained Access / RBAC with OpenFGA`
+- Apollo Federation v2.9 Authorization: https://www.apollographql.com/docs/graphos/schema-design/federation/authorization
+- OpenFGA Documentation: https://openfga.dev/docs/intro
+- `schema/x-graphql-extensions.schema.json` (vendor extension definitions)
+- `website/pages/docs/recipes/federation.mdx`

--- a/docs/adr/0012-caching-and-schema-evolution.md
+++ b/docs/adr/0012-caching-and-schema-evolution.md
@@ -1,0 +1,116 @@
+# 0012: Dynamic Caching, Schema Drift Detection, and Independent Subgraph Evolution
+
+Date: 2026-06-05
+
+## Status
+
+Accepted
+
+## Context
+
+Enterprise federated architectures face three interrelated challenges:
+1. **Legacy API resilience**: Heavy queries must not overload upstream systems or cause outages
+2. **Schema drift**: Independent subgraph teams can introduce breaking changes that break the supergraph composition
+3. **Independent evolution**: Teams must be able to evolve their schemas without cross-team coordination
+
+These problems must be solved together — caching without schema governance leads to stale data; schema governance without caching leads to brittle performance requirements.
+
+## Decision
+
+Adopt a **three-pillar architecture**: Cache Layer + Schema Management System + Versioned Storage.
+
+### Pillar 1: Dynamic Caching & Cache Reindexing
+
+**Goal:** Prevent legacy API outages and ensure low-latency responses.
+
+| Pattern | Implementation | Rationale |
+|---------|----------------|-----------|
+| **Dedicated Cache Layer** | Redis as the distributed gateway cache | GraphQL Portal and other gateways natively rely on Redis for distributed node management |
+| **Materialized Views** | Scheduled refreshes to Apache Iceberg | Acts as a background worker/queue; reindexes cache incrementally without overloading upstream |
+| **Cache Service Redirection** | Automatic table scan redirection to materialized copies | Gives federation the flexibility of distributed data with warehouse-like performance for hot data |
+| **Webhook Invalidation** | Event-driven cache invalidation instead of polling | Legacy systems push update events to invalidate specific entity caches |
+
+**Principle:** Decouple heavy queries from live operational databases. The cache is a first-class layer, not an afterthought.
+
+### Pillar 2: Schema Drift Detection & Version Control
+
+**Goal:** Detect breaking changes before they reach runtime.
+
+| Layer | Mechanism |
+|-------|-----------|
+| **CI/CD Composition Checks** | Automated validation of schema compatibility, ownership boundaries, and type extensions |
+| **Multi-Stage Schema Management** | Unit schemas → staging validation → production approval |
+| **Storage-Level Schema Evolution** | Apache Iceberg native schema evolution and time travel for materialized caches |
+
+**Principle:** The supergraph is not manually written — it is generated through a composition pipeline that validates governance rules before publication.
+
+### Pillar 3: Independent Subgraph Evolution
+
+**Goal:** Enable teams to evolve their APIs without breaking the supergraph.
+
+**Three-Layer Schema Architecture:**
+
+```
+Unit Schema (team-owned)
+    |
+    v
+Subgraph Schema (composition unit)
+    |
+    v
+Supergraph Schema (consumer contract)
+```
+
+- **Unit Schemas**: Individual teams develop their APIs independently
+- **Subgraph Schemas**: The schema management system automatically merges unit schemas into subgraph schemas
+- **Supergraph Schema**: Composed from validated subgraphs; the only contract consumers see
+
+**Declarative Extensions:**
+- `x-graphql-external`: Declare fields originating elsewhere
+- `x-graphql-provides`: Dictate survivorship and resolution rules
+- `x-graphql-key`: Establish entity identity for cross-subgraph references
+
+**Principle:** Domains explicitly declare their entity representations. The federated router dynamically handles join logic at runtime. Teams add new types to their unit schemas; as long as they pass composition checks, the router automatically exposes them.
+
+## Consequences
+
+### Positive
+- **Resilience**: Materialized views + webhooks prevent legacy API overload
+- **Governance**: Automated composition rejects breaking changes before production
+- **Autonomy**: Teams evolve independently within validated boundaries
+- **Observability**: Iceberg time travel provides reproducible schema snapshots
+
+### Negative
+- **Operational complexity**: Three new systems (Redis, Iceberg, schema management) to operate
+- **Eventual consistency**: Materialized views introduce lag between upstream change and cache refresh
+- **Migration effort**: Existing schemas must be restructured into the three-layer hierarchy
+
+### Mitigation
+- Start with Redis caching only (no Iceberg) for the first phase
+- Implement the schema management system as a GitHub Action before building a full UI
+- Use Iceberg's time travel only for audit/debugging, not for normal query serving
+
+## Implementation Strategy
+
+### Phase 1: Cache Layer (Short-term)
+- Redis integration in the gateway/router
+- Webhook endpoint for cache invalidation
+- TTL-based materialization for frequently accessed queries
+
+### Phase 2: Schema Management System (Medium-term)
+- GitHub Action for supergraph composition validation
+- Staging environment for subgraph schema previews
+- Breaking change detection with `@theguild/federation-composition`
+
+### Phase 3: Full Data Federation (Long-term)
+- Apache Iceberg materialized views
+- Time-travel debugging for schema drift
+- Cross-domain analytics via the federated cache layer
+
+## References
+
+- Issue #84: `Support for Subgraph independence, with organic federated schema evolution and dynamic caching strategies`
+- Issue #10: `@theguild/federation-composition` (composition validation)
+- Apache Iceberg: https://iceberg.apache.org/
+- OpenFGA (for authorization layer): ADR 0011
+- `website/pages/docs/adr/0008-subgraph-supergraph-metadata-naming.mdx`
+- `website/pages/docs/recipes/federation.mdx`

--- a/docs/concepts/data-engineering-federation-mapping.md
+++ b/docs/concepts/data-engineering-federation-mapping.md
@@ -1,0 +1,139 @@
+# Data Engineering Concepts ↔ GraphQL Federation
+
+> If you already understand data engineering (canonical models, provenance, survivorship, joins), this guide maps those concepts to their GraphQL Federation equivalents.
+
+---
+
+## Canonical Data Models ↔ The Supergraph and Entities
+
+**Data Engineering:** A canonical model represents the single source of truth — the authoritative schema for an organization.
+
+**GraphQL Federation:** This concept maps to the **Supergraph**, which is the unified, composed contract exposing all types, fields, and cross-domain relationships to API consumers.
+
+At the individual object level, the canonical record is an **Entity** — a type decorated with `@key` to establish its primary key representation so multiple subgraphs can reference the exact same object.
+
+```graphql
+type User @key(fields: "id") {
+  id: ID!
+  name: String
+}
+```
+
+**Where they meet:** During **Composition**, the process that enforces governance by validating schema compatibility, ensuring consistent type definitions, and checking ownership boundaries before the canonical contract is published.
+
+---
+
+## Data Provenance and Lineage ↔ Subgraph Ownership and Directives
+
+**Data Engineering:** Provenance and lineage tracking tell you where data came from and how it flows downstream.
+
+**GraphQL Federation:** This is achieved through explicit **Subgraph Ownership** and field-level directives:
+
+| Directive | Meaning |
+|-----------|---------|
+| `@external` | "This field originates from another subgraph" |
+| `@requires` | "I need these specific fields from other subgraphs to compute my value" |
+
+```graphql
+type Billing @extends @key(fields: "id") {
+  id: ID! @external
+  creditScore: Int @requires(fields: "id name")
+}
+```
+
+**Where they meet:** In the **declarative schema definitions**. The subgraph explicitly declares its upstream dependencies, preventing ambiguous ownership and establishing clear accountability.
+
+---
+
+## Survivorship ↔ Field Resolution Rules
+
+**Data Engineering:** Survivorship rules determine which source "wins" when multiple systems provide overlapping attributes.
+
+**GraphQL Federation:** Survivorship is codified into the schema using directives:
+
+| Directive | Meaning |
+|-----------|---------|
+| `@override` | "This subgraph is now the authoritative source for this field" |
+| `@provides` | "I can resolve this field even though another subgraph normally owns it" |
+
+```graphql
+type Product @key(fields: "id") {
+  id: ID!
+  name: String @override(from: "legacy-catalog")
+  inStock: Boolean @provides(fields: "id")
+}
+```
+
+**Where they meet:** Inside the **Router**. The router reads these survivorship directives at runtime to orchestrate operations and determine exactly which subgraph's resolver is authoritative for a given field.
+
+---
+
+## Concatenation and Joins ↔ Cross-Subgraph Resolution
+
+**Data Engineering:** Bottom-up pipelines rely on query federation and joins to combine data from heterogeneous systems.
+
+**GraphQL Federation:** The equivalent is **Cross-Subgraph Resolution**. The router receives a single query, breaks it into subgraph-specific operations, orchestrates execution across domains, and aggregates the responses into a single result.
+
+Instead of building brittle ETL pipelines to join data across systems, domains simply reference entities from other domains in their schema:
+
+```graphql
+# Billing subgraph references User and Policy entities
+type Invoice @key(fields: "id") {
+  id: ID!
+  customer: User
+  policy: Policy
+  amount: Float
+}
+```
+
+**Where they meet:** Through **Declarative Entity References**. The router handles the join logic dynamically at runtime, creating a connected graph without physically centralizing the data.
+
+---
+
+## Data Transformation ↔ Response Translation Adapters
+
+**Data Engineering:** ETL/ELT pipelines transform raw system-level data into consumable formats.
+
+**GraphQL Federation:** This maps to the **Response Translation** phase of the emulation engine.
+
+Instead of heavy ETL pipelines, the engine intercepts raw REST or database JSON responses and recursively applies metadata rules defined in the extended schema:
+
+```json
+{
+  "properties": {
+    "user_name": {
+      "type": "string",
+      "x-graphql-field-name": "userName"
+    }
+  }
+}
+```
+
+**Where they meet:** At the **three-namespace design layer** (`x-graphql-field-name`, `x-graphql-type-name`). Raw `snake_case` backend properties are automatically converted into clean, typed, idiomatic `camelCase` GraphQL objects.
+
+---
+
+## Quick Reference Table
+
+| Data Engineering | GraphQL Federation | Directive / Concept |
+|------------------|--------------------|---------------------|
+| Canonical model | Supergraph | Composition |
+| Primary key | Entity `@key` | `@key(fields: "id")` |
+| Foreign key | Cross-subgraph reference | `@external` + `@key` |
+| Borrowed column | Borrowed field | `@external` |
+| Denormalized / eager-loaded | Eager resolution | `@provides` |
+| Computed column | Computed field | `@requires` |
+| Shared table | Shared type | `@shareable` |
+| Database / schema namespace | Subgraph | `x-graphql-subgraph-name` |
+| Data provenance | Subgraph ownership | `@external`, `@requires` |
+| Survivorship | Authoritative source | `@override`, `@provides` |
+| ETL transformation | Response translation | `x-graphql-field-name` |
+
+---
+
+## See Also
+
+- ADR 0008: Subgraph/Supergraph Metadata Naming
+- ADR 0010: Visual Editor Design
+- ADR 0011: Fine-Grained Authorization
+- `website/pages/docs/recipes/federation.mdx`

--- a/docs/status/issue-triage-summary-2026-06-05.md
+++ b/docs/status/issue-triage-summary-2026-06-05.md
@@ -1,0 +1,77 @@
+# Issue Triage Summary — 2026-06-05
+
+## Actions Taken
+
+### ADRs Created
+| Issue | Action | New Document |
+|-------|--------|--------------|
+| #85 | Converted to ADR | `docs/adr/0010-visual-editor-design.md` |
+| #84 | Converted to ADR | `docs/adr/0012-caching-and-schema-evolution.md` |
+| #83 | Converted to ADR | `docs/adr/0011-fine-grained-authorization.md` |
+| #82 | Converted to docs page | `docs/concepts/data-engineering-federation-mapping.md` |
+
+### Proposed Comments for GitHub Issues
+
+#### Issue #85 — Visual Editor Design Guide
+> This design guide has been consolidated into ADR 0010: Visual Editor Design for Federated Subgraph ERD.
+> 
+> → `docs/adr/0010-visual-editor-design.md`
+> 
+> The ADR establishes the dual-visualization strategy (graphql-voyager + custom ER diagram) and the visual design system. Implementation is tracked in #19 (voyager) and #20 (ER diagram).
+> 
+> **Proposed action:** Close this issue as the design work is now captured in the ADR.
+
+#### Issue #84 — Subgraph Independence / Caching
+> This architectural proposal has been consolidated into ADR 0012: Dynamic Caching, Schema Drift Detection, and Independent Subgraph Evolution.
+> 
+> → `docs/adr/0012-caching-and-schema-evolution.md`
+> 
+> The ADR breaks the proposal into three pillars (Cache Layer, Schema Management System, Independent Subgraph Evolution) with phased implementation strategy.
+> 
+> **Proposed action:** Close this issue as the architecture is now captured in the ADR. Future implementation work will be tracked as child issues under the epic.
+
+#### Issue #83 — OpenFGA / RBAC
+> This security proposal has been consolidated into ADR 0011: Fine-Grained Authorization via @policy Directive and OpenFGA.
+> 
+> → `docs/adr/0011-fine-grained-authorization.md`
+> 
+> The ADR documents the three-layer authorization architecture. The converter already supports `@policy` (commit f414f51). The remaining work is the router plugin and validation tooling.
+> 
+> **Proposed action:** Close this issue as the design is now captured in the ADR.
+
+#### Issue #82 — ELI5 / Data Engineering Mapping
+> This conceptual explainer has been converted into a permanent docs page.
+> 
+> → `docs/concepts/data-engineering-federation-mapping.md`
+> 
+> The page maps canonical data models, provenance, survivorship, joins, and transformations to their GraphQL Federation equivalents with a quick-reference table.
+> 
+> **Proposed action:** Close this issue as the content is now in the docs.
+
+#### Issue #60 — Review Visualization Editors
+> **Proposed action:** Close as superseded by #19 (graphql-voyager) and #20 (federation ER diagram). The ADR 0010 documents the chosen visualization strategy.
+
+#### Issue #44 — Standard Schema
+> **Proposed action:** Convert to a spike issue for a proof-of-concept adapter. Standard Schema is an emerging spec with high future value.
+
+#### Issue #43 — simdjson
+> **Proposed action:** Label `research` + `performance` and close or backlog. Only relevant if JSON parsing becomes a bottleneck.
+
+#### Issue #41 — Zod Schema
+> **Proposed action:** Label `research` and close or backlog. Overlaps with core converter mission but could be a future plugin.
+
+### Deferred Issues Grouping
+Issues #7–#17 should be grouped into a single epic: **"v2.1 Ecosystem Rehydration"**
+
+## Implementation Status
+
+### Completed (via subagents)
+- **#19 (graphql-voyager):** Implementation complete in `frontend/subgraph-composer`. VoyagerPanel component, lazy loading, tab integration, subgraph color-coding, tests passing.
+- **Node converter fixes:** Circular reference protection, enhanced `$ref` resolution with case fallback, `$defs` extraction verification. 158 tests passing.
+
+### Remaining
+- **Docs page for voyager:** `website/pages/docs/internals/voyager.mdx` (not yet created)
+- **Build verification:** `pnpm build` in `frontend/subgraph-composer` (not yet run)
+- **ER diagram (#20):** Not yet started
+- **Router plugin (ADR 0011):** Not yet started
+- **Cache layer (ADR 0012):** Not yet started


### PR DESCRIPTION
# docs: add ADRs for federation visualization, authorization, and caching

**Branch:** `docs/adr-federation-concepts`
**Base:** `main`

## Summary

Converts four high-quality "essay" issues into permanent ADRs and documentation pages.

## Documents Added

| Document | From Issue | Description |
|----------|-----------|-------------|
| `docs/adr/0010-visual-editor-design.md` | #85 | Dual-visualization strategy (graphql-voyager + custom ER diagram) |
| `docs/adr/0011-fine-grained-authorization.md` | #83 | Three-layer auth architecture (Schema → Router → OpenFGA) |
| `docs/adr/0012-caching-and-schema-evolution.md` | #84 | Three-pillar architecture (Cache + Schema Management + Evolution) |
| `docs/concepts/data-engineering-federation-mapping.md` | #82 | Data engineering concepts mapped to GraphQL Federation |
| `docs/status/issue-triage-summary-2026-06-05.md` | — | Proposed actions for each open issue |

## Related

- Closes #82, #83, #84, #85
