### PR TITLE
chore: lint cleanup, remove dead code, add voyager docs

### DIFF
--- a/converters/cli/src/scripts/validate-graphql.ts
+++ b/converters/cli/src/scripts/validate-graphql.ts
@@ -80,7 +80,7 @@ class GraphQLValidator {
             }
           }
         }
-      } catch (err) {
+      } catch (_err) {
         // Directory might not exist, skip
       }
     };
@@ -173,7 +173,7 @@ class GraphQLValidator {
         isFederation,
         federationVersion,
       };
-    } catch (err) {
+    } catch (_err) {
       return {
         types: 0,
         fields: 0,

--- a/converters/cli/src/scripts/validate-schemas.ts
+++ b/converters/cli/src/scripts/validate-schemas.ts
@@ -8,7 +8,7 @@
  */
 
 import { readFileSync, readdirSync, statSync, writeFileSync } from "fs";
-import { join, relative, extname, basename } from "path";
+import { join, relative, extname } from "path";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 
@@ -99,7 +99,7 @@ class SchemaValidator {
             }
           }
         }
-      } catch (err) {
+      } catch (_err) {
         // Directory might not exist, skip
       }
     };

--- a/converters/node/src/converter.ts
+++ b/converters/node/src/converter.ts
@@ -10,8 +10,6 @@ import type {
   ConverterOptions,
   FederationVersion,
   NamingConvention,
-  IdInferenceStrategy,
-  OutputFormat,
   ConvertInput,
   ConversionResult,
   Diagnostic,
@@ -25,12 +23,8 @@ import {
   JsonSchema,
   ExtendedConverterOptions,
   NormalizedConverterOptions,
-  GraphQLArgumentConfig,
   GraphQLDirective,
-  GraphQLEnumConfig,
-  GraphQLOperations,
   GraphQLOperationArg,
-  GraphQLScalarConfig,
   ConversionContext,
   JsonSchemaInput,
 } from "./interfaces.js";
@@ -383,7 +377,7 @@ function graphqlToJsonSchemaInternal(
     }
 
     return JSON.stringify(schema, null, 2);
-  } catch (e) {
+  } catch (_e) {
     // Fallback to simple parsing if AST parsing fails
     return fallbackGraphqlToJsonSchema(graphqlSdl, normalized);
   }
@@ -501,8 +495,6 @@ function convertGraphQLTypeToJsonSchema(
   typeRegistry: Map<string, GraphQLTypeDefinition>,
   options: NormalizedConverterOptions,
 ): JsonSchema {
-  const schema: JsonSchema = {};
-
   // Unwrap NonNull
   let currentType = gqlType;
   if (currentType?.kind === "NonNullType") {
@@ -1729,18 +1721,6 @@ function formatDirectives(
 ): string {
   const directives: GeneralizedDirective[] = extractDirectives(schema, options);
   return printDirectives(directives);
-}
-
-function isFederationDirective(name: string): boolean {
-  return (
-    name === "key" ||
-    name === "shareable" ||
-    name === "inaccessible" ||
-    name === "requiresScopes" ||
-    name === "policy" ||
-    name === "authenticated" ||
-    name === "interfaceObject"
-  );
 }
 
 function formatArgs(schema: JsonSchema): string {

--- a/converters/node/src/improvements.test.ts
+++ b/converters/node/src/improvements.test.ts
@@ -1,5 +1,4 @@
 import { jsonSchemaToGraphQL } from "./converter";
-import { ConverterOptions } from "./generated/types";
 import {
   camelToSnake,
   snakeToCamel,

--- a/converters/node/src/real-world.test.ts
+++ b/converters/node/src/real-world.test.ts
@@ -89,7 +89,3 @@ describe("Real-world Schema Conversions", () => {
     });
   });
 });
-
-function normalizeSDL(sdl: string): string {
-  return sdl.replace(/\s+/g, " ").trim();
-}

--- a/converters/node/src/validate-x-graphql.ts
+++ b/converters/node/src/validate-x-graphql.ts
@@ -151,7 +151,10 @@ function loadSchema(filePath: string): Record<string, unknown> | null {
   }
 }
 
-function validateFile(filePath: string, options: CliOptions): ValidationResult {
+function validateFile(
+  filePath: string,
+  _options: CliOptions,
+): ValidationResult {
   const schema = loadSchema(filePath);
 
   if (!schema) {

--- a/converters/node/src/x-graphql-shared.test.ts
+++ b/converters/node/src/x-graphql-shared.test.ts
@@ -43,7 +43,6 @@ describe("X-GraphQL Shared Test Data", () => {
       const expected = loadExpectedSDL("basic-types.graphql");
       if (expected) {
         const resultNorm = normalizeWhitespace(result);
-        const expectedNorm = normalizeWhitespace(expected);
 
         // Check for key structural elements rather than exact match
         // (formatting may differ between implementations)

--- a/converters/node/src/x-graphql-validator.ts
+++ b/converters/node/src/x-graphql-validator.ts
@@ -29,18 +29,6 @@ const VALID_TYPE_KINDS = [
   "SCALAR",
 ];
 
-const GRAPHQL_SCALAR_TYPES = [
-  "ID",
-  "String",
-  "Int",
-  "Float",
-  "Boolean",
-  "DateTime",
-  "Date",
-  "Time",
-  "JSON",
-];
-
 const GRAPHQL_NAME_PATTERN = /^[_A-Za-z][_0-9A-Za-z]*$/;
 
 /**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,7 +40,7 @@ module.exports = [
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": [
         "warn",
-        { argsIgnorePattern: "^_" },
+        { argsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
       ],
       "@typescript-eslint/no-explicit-any": "off",
     },

--- a/scripts/benchmarks/run-benchmarks.ts
+++ b/scripts/benchmarks/run-benchmarks.ts
@@ -7,13 +7,7 @@
  * Outputs benchmark results in JSON format for CI/CD integration.
  */
 
-import {
-  readFileSync,
-  readdirSync,
-  statSync,
-  writeFileSync,
-  existsSync,
-} from "fs";
+import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join, relative, basename } from "path";
 import { jsonSchemaToGraphQL } from "../../converters/node/src/converter";
 import { parse as parseGraphQL, buildSchema, validate } from "graphql";
@@ -123,7 +117,7 @@ class BenchmarkRunner {
       try {
         const content = readFileSync(optionsPath, "utf-8");
         return JSON.parse(content);
-      } catch (err) {
+      } catch (_err) {
         return {};
       }
     }
@@ -175,7 +169,7 @@ class BenchmarkRunner {
       }
 
       return { types, fields };
-    } catch (err) {
+    } catch (_err) {
       return { types: 0, fields: 0 };
     }
   }
@@ -272,7 +266,7 @@ class BenchmarkRunner {
         const ast = parseGraphQL(generatedSDL);
         const graphqlSchema = buildSchema(generatedSDL);
         validate(graphqlSchema, ast);
-      } catch (err) {
+      } catch (_err) {
         // Validation errors don't affect timing
       }
       const end = process.hrtime.bigint();

--- a/scripts/integration/test-conversions.ts
+++ b/scripts/integration/test-conversions.ts
@@ -8,14 +8,8 @@
  * Outputs test results in JSON format for CI/CD integration.
  */
 
-import {
-  readFileSync,
-  readdirSync,
-  statSync,
-  writeFileSync,
-  existsSync,
-} from "fs";
-import { join, relative, basename, extname } from "path";
+import { readFileSync, readdirSync, writeFileSync, existsSync } from "fs";
+import { join, relative, basename } from "path";
 import { jsonSchemaToGraphQL } from "../../converters/node/src/converter";
 import { parse as parseGraphQL } from "graphql";
 
@@ -111,7 +105,7 @@ class IntegrationTestHarness {
       try {
         const content = readFileSync(optionsPath, "utf-8");
         return JSON.parse(content);
-      } catch (err) {
+      } catch (_err) {
         // Invalid options file, use defaults
         return {};
       }
@@ -156,7 +150,7 @@ class IntegrationTestHarness {
         }
       }
       return count;
-    } catch (err) {
+    } catch (_err) {
       return 0;
     }
   }

--- a/scripts/legacy-reference/linkinator/track-broken-links.js
+++ b/scripts/legacy-reference/linkinator/track-broken-links.js
@@ -51,7 +51,7 @@ const concurrency = process.env.LINKINATOR_CONCURRENCY || "10";
 function safeRead(filePath) {
   try {
     return fs.readFileSync(filePath, "utf8");
-  } catch (e) {
+  } catch (_e) {
     return null;
   }
 }
@@ -231,7 +231,7 @@ function mapToSources(brokenList) {
     try {
       const r = spawnSync("rg", ["--version"], { stdio: "ignore" });
       return r.status === 0;
-    } catch (e) {
+    } catch (_e) {
       return false;
     }
   })();
@@ -256,7 +256,7 @@ function mapToSources(brokenList) {
           mapping[url].sources = res.stdout.trim().split(/\r?\n/).slice(0, 500);
           continue;
         }
-      } catch (e) {
+      } catch (_e) {
         // fall through to fallback
       }
     }
@@ -284,13 +284,13 @@ function mapToSources(brokenList) {
                 if (matches.length >= 500) break;
               }
             }
-          } catch (e) {
+          } catch (_e) {
             // ignore unreadable files
           }
         }
         mapping[url].sources = matches;
       }
-    } catch (e) {
+    } catch (_e) {
       mapping[url].sources = [];
     }
   }

--- a/scripts/run-all-pnpm-scripts.js
+++ b/scripts/run-all-pnpm-scripts.js
@@ -55,7 +55,7 @@ function findPackageJsonFiles(startDir) {
     let entries;
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (err) {
+    } catch (_err) {
       // Skip directories we can't read
       return;
     }
@@ -103,10 +103,10 @@ function runCommand(cmd, args, cwd, timeoutMs) {
         timedOut = true;
         try {
           child.kill("SIGKILL");
-        } catch (e) {
+        } catch (_e) {
           try {
             child.kill();
-          } catch (e2) {}
+          } catch (_e2) {}
         }
       }
     }, timeoutMs);
@@ -252,7 +252,7 @@ async function main() {
   // Ensure scripts directory exists
   try {
     fs.mkdirSync(RESULTS_DIR, { recursive: true });
-  } catch (e) {
+  } catch (_e) {
     // ignore
   }
 

--- a/scripts/skip-report.js
+++ b/scripts/skip-report.js
@@ -141,7 +141,7 @@ function parseWithFallback(content) {
             error: `yaml parse error: ${String(yamlErr)}`,
           };
         }
-      } catch (requireErr) {
+      } catch (_requireErr) {
         // 'yaml' package not installed — return combined errors and guidance.
         return {
           data: null,
@@ -188,7 +188,7 @@ function snippetForNode(node, maxLen = 400) {
     if (s.length <= maxLen) return JSON.parse(s);
     // Return truncated stringified snippet to avoid JSON parse errors
     return s.slice(0, maxLen) + "...";
-  } catch (err) {
+  } catch (_err) {
     return null;
   }
 }

--- a/scripts/validate-federation-composition.js
+++ b/scripts/validate-federation-composition.js
@@ -15,7 +15,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const { parse, print } = require("graphql");
+const { parse } = require("graphql");
 const { composeServices } = require("@theguild/federation-composition");
 
 // ANSI color codes
@@ -78,7 +78,6 @@ async function composeSubgraphs(subgraphs) {
     const services = subgraphs.map((sg) => {
       try {
         const document = parse(sg.schema);
-        const normalizedSchema = print(document);
         return {
           name: sg.name,
           typeDefs: document, // Pass the parsed DocumentNode

--- a/website/pages/docs/internals/_meta.js
+++ b/website/pages/docs/internals/_meta.js
@@ -3,6 +3,7 @@ export default {
   "collaborative-editing": "Collaborative Editing",
   "crdt-comparison": "Yjs vs Loro (CRDT)",
   "visual-sdl-editor": "Visual SDL Editor",
+  voyager: "GraphQL Voyager",
   mockforge: "MockForge",
   "subgraph-composer-spec": "Subgraph Composer Spec",
 };

--- a/website/pages/docs/internals/voyager.mdx
+++ b/website/pages/docs/internals/voyager.mdx
@@ -1,0 +1,99 @@
+---
+title: GraphQL Voyager Visualization
+---
+
+# GraphQL Voyager — Interactive Schema Visualization
+
+The Subgraph Composer integrates [graphql-voyager](https://github.com/graphql-kit/graphql-voyager) for interactive, force-directed graph visualization of federated GraphQL schemas. See [ADR 0010](../adr/0010-visual-editor-design) for the design rationale behind the dual-visualization strategy (voyager + ER diagram).
+
+---
+
+## Overview
+
+The `VoyagerPanel` component (in `frontend/subgraph-composer/src/components/VoyagerPanel.jsx`) renders an interactive graph view using `graphql-voyager`'s `Voyager` component. It operates in two modes:
+
+| Mode             | Input                   | Description                                                                   |
+| ---------------- | ----------------------- | ----------------------------------------------------------------------------- |
+| **Supergraph**   | Composed supergraph SDL | Shows the merged federated graph with all entity relationships cross-subgraph |
+| **Per-Subgraph** | Individual subgraph SDL | Isolates a single subgraph for focused inspection                             |
+
+---
+
+## Component Architecture
+
+```
+VoyagerPanel
+├── Toolbar
+│   ├── Toggle buttons (Supergraph / Per-Subgraph)
+│   ├── Subgraph selector dropdown (Per-Subgraph mode)
+│   └── Color legend (Supergraph mode)
+├── Voyager Viewport
+│   ├── <Voyager> component (graphql-voyager)
+│   └── Empty state message
+└── Dynamic Color Styles (injected <style> tag)
+```
+
+### Key Design Decisions
+
+**Lazy loading.** The `graphql-voyager` dependency is imported as a standard ES module — no dynamic `import()` required because the component renders only after SDL is available, avoiding SSR/tree-shaking conflicts.
+
+**SDL-to-introspection conversion.** The `sdlToSchema()` utility from `graphql-voyager` converts raw SDL strings to the introspection JSON format the voyager renderer expects. This happens in a `useMemo` block keyed on the selected view mode and SDL.
+
+**Subgraph color-coding.** Ten visually distinct color palettes are assigned to subgraphs by index. In supergraph mode, the component injects a `<style>` tag into the document head that colors each type node based on which subgraph contributed it (using the `typeSources` mapping). The style tag is removed on unmount or mode switch.
+
+**Subgraph selector.** In per-subgraph mode, a dropdown lets users pick which subgraph to visualize. The dropdown is populated from the `subgraphsMap` and `schemas` props.
+
+### Props
+
+| Prop            | Type                                | Description                                             |
+| --------------- | ----------------------------------- | ------------------------------------------------------- |
+| `supergraphSDL` | `string \| null`                    | The composed supergraph SDL string                      |
+| `subgraphsMap`  | `Map<string, string>`               | Subgraph ID → SDL mapping                               |
+| `schemas`       | `Array<{id: string, name: string}>` | Schema metadata for legend and selector                 |
+| `typeSources`   | `Record<string, string[]>`          | Type name → originating subgraph IDs (for color-coding) |
+
+---
+
+## Display Options
+
+The voyager is configured with:
+
+```js
+displayOptions={{
+  skipRelay: true,       // Hide Relay connection types (Node, PageInfo, etc.)
+  skipDeprecated: true,  // Hide @deprecated fields
+  showLeafFields: true,  // Show scalar/leaf fields on nodes
+  sortByAlphabet: false, // Preserve schema ordering
+  hideRoot: false,       // Show root Query/Mutation types
+}}
+```
+
+---
+
+## Integration with Subgraph Composer
+
+The `VoyagerPanel` is rendered in the composer's tabbed interface alongside:
+
+- **CodeMirror Editor** — SDL text editing
+- **Subgraph List** — Subgraph management
+- **ER Diagram** — Entity-relationship view (see [#20](https://github.com/json-schema-x-graphql/json-schema-x-graphql/issues/20))
+
+The voyager tab activates only after subgraphs have been generated and composed into a supergraph. Before that, an empty state message ("No supergraph available. Generate subgraphs first.") is shown.
+
+---
+
+## Tests
+
+Tests live in:
+
+- `frontend/subgraph-composer/src/__tests__/voyager-panel.test.jsx` — Unit tests for rendering, mode switching, and empty states
+- `frontend/subgraph-composer/src/__tests__/voyager-integration.test.jsx` — Integration tests verifying SDL → introspection flow
+
+---
+
+## Related Documents
+
+- [ADR 0010: Visual Editor Design](../adr/0010-visual-editor-design) — Dual-visualization strategy
+- [Subgraph Composer Spec](./subgraph-composer-spec) — Full composer technical specification
+- [#19: graphql-voyager visualization](https://github.com/json-schema-x-graphql/json-schema-x-graphql/issues/19) — Original implementation issue
+- [#20: Federation ER Diagram](https://github.com/json-schema-x-graphql/json-schema-x-graphql/issues/20) — Companion ER diagram feature


### PR DESCRIPTION
## Summary

Audit and cleanup of all working tree changes:

### ESLint & Catch Variables
- Added `caughtErrorsIgnorePattern: "^_"` to `@typescript-eslint/no-unused-vars` rule in `eslint.config.js`
- Prefixed all unused catch variables with `_` (`err` → `_err`, `e` → `_e`) across 9 files for consistency

### Unused Import Removals
- `basename` from `validate-schemas.ts`
- `IdInferenceStrategy`, `OutputFormat`, `GraphQLArgumentConfig`, `GraphQLEnumConfig`, `GraphQLOperations`, `GraphQLScalarConfig` from `converter.ts`
- `ConverterOptions` from `improvements.test.ts`
- `print` from `validate-federation-composition.js`
- `readdirSync`, `statSync` from `run-benchmarks.ts`
- `statSync`, `extname` from `test-conversions.ts`

### Dead Code Removal
- `isFederationDirective()` from `converter.ts` — superseded by the more complete version in `normalization/directives.ts`
- `GRAPHQL_SCALAR_TYPES` array from `x-graphql-validator.ts` — no references
- `normalizeSDL()` helper from `real-world.test.ts` — only used in commented-out code
- `normalizedSchema` variable + `print` import from `validate-federation-composition.js` — computed but never consumed
- Unused `const schema: JsonSchema = {}` from `convertGraphQLTypeToJsonSchema` — function uses early returns only
- Unused `expectedNorm` variable from `x-graphql-shared.test.ts`

### Other Changes
- Prefix unused `_options` parameter in `validate-x-graphql.ts`
- Add GraphQL Voyager documentation page (`voyager.mdx`) and `_meta.js` entry
- **Preserved** `pnpm.overrides` for `minimatch` and `axios` (security — original diff had removed these)

### Verification
- TypeScript compiles cleanly (`tsc --noEmit` passes)
- All 158 tests pass