### PR TITLE
fix: security audit — Dependabot/CodeQL findings, dead code, error handling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,57 @@
 version: 2
 updates:
-  # Manage the entire pnpm workspace dependencies from the root
+  # Root pnpm workspace — use npm ecosystem for pnpm-lock.yaml
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+
+  # Frontend dashboard workspace
+  - package-ecosystem: "npm"
+    directory: "/frontend/dashboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Converter node workspace
+  - package-ecosystem: "npm"
+    directory: "/converters/node"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Converter CLI workspace
+  - package-ecosystem: "npm"
+    directory: "/converters/cli"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Frontend subgraph-composer workspace
+  - package-ecosystem: "npm"
+    directory: "/frontend/subgraph-composer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Website workspace
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Rust Cargo ecosystem
+  - package-ecosystem: "cargo"
+    directory: "/converters/rust"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn.lock
 
 # Testing
 /coverage/
+**/coverage/
 /converters/node/coverage/*
 /.nyc_output/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,4 @@ output/
 frontend/dashboard/scripts/
 **/generated/
 frontend/dashboard/src/data/
+**/salvaged/**/wasm/

--- a/converters/cli/package.json
+++ b/converters/cli/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@apollo/subgraph": "^2.9.3",
     "@json-schema-x-graphql/core": "workspace:*",
-    "ajv": "8.17.1",
+    "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "graphql": "^16.14.0"
   },

--- a/converters/node/src/converter.ts
+++ b/converters/node/src/converter.ts
@@ -470,11 +470,7 @@ function convertGraphQLFieldToSchema(
   typeRegistry: Map<string, GraphQLTypeDefinition>,
   options: NormalizedConverterOptions,
 ): JsonSchema {
-  const typeSchema = convertGraphQLTypeToJsonSchema(
-    field.type,
-    typeRegistry,
-    options,
-  );
+  const typeSchema = convertGraphQLTypeToJsonSchema(field.type, typeRegistry);
 
   // Merge description if present
   if (field.description?.value && options.includeDescriptions) {
@@ -493,7 +489,6 @@ function convertGraphQLFieldToSchema(
 function convertGraphQLTypeToJsonSchema(
   gqlType: any,
   typeRegistry: Map<string, GraphQLTypeDefinition>,
-  options: NormalizedConverterOptions,
 ): JsonSchema {
   // Unwrap NonNull
   let currentType = gqlType;
@@ -505,11 +500,7 @@ function convertGraphQLTypeToJsonSchema(
   if (currentType?.kind === "ListType") {
     return {
       type: "array",
-      items: convertGraphQLTypeToJsonSchema(
-        currentType.type,
-        typeRegistry,
-        options,
-      ),
+      items: convertGraphQLTypeToJsonSchema(currentType.type, typeRegistry),
     };
   }
 
@@ -1710,9 +1701,13 @@ function formatDescription(
   const shouldBlock =
     description.includes("\n") || description.length >= BLOCK_THRESHOLD;
   if (shouldBlock) {
-    return `"""${description.replace(/"""/g, '\\"\"\"')}"""`;
+    // Escape backslashes first, then triple-quote sequences
+    const escaped = description.replace(/\\/g, "\\\\").replace(/"""/g, '\\"""');
+    return `"""${escaped}"""`;
   }
-  return `"${description.replace(/"/g, '\\"')}"`;
+  // Escape backslashes first, then quotes
+  const escaped = description.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
 }
 
 function formatDirectives(

--- a/examples/mesh-gateway/package.json
+++ b/examples/mesh-gateway/package.json
@@ -4,10 +4,10 @@
   "description": "Gateway Stitching & Federated REST Emulation using json-schema-x-graphql",
   "main": "gateway.js",
   "dependencies": {
-    "@apollo/server": "^4.11.0",
+    "@apollo/server": "^4.13.0",
     "@apollo/subgraph": "^2.9.0",
     "@apollo/gateway": "^2.9.0",
-    "axios": "^1.7.9",
+    "axios": "^1.16.1",
     "graphql": "^16.14.0",
     "graphql-tag": "^2.12.6",
     "yaml": "^2.3.4",

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -97,7 +97,7 @@
     "@omnigraph/json-schema": "^0.109.16",
     "@tanstack/react-query": "^5.90.2",
     "allotment": "^1.20.4",
-    "axios": "0.30.3",
+    "axios": "^1.16.1",
     "dayjs": "^1.11.18",
     "fast-xml-parser": "^5.3.0",
     "gofmt.js": "^0.0.2",
@@ -189,12 +189,5 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "packageManager": "pnpm@10.13.1",
-  "pnpm": {
-    "overrides": {
-      "axios": "0.30.3",
-      "tar": "7.5.8",
-      "handlebars": "4.7.9"
-    }
-  }
+  "packageManager": "pnpm@10.13.1"
 }

--- a/frontend/dashboard/src/lib/utils/jsonAdapter.ts
+++ b/frontend/dashboard/src/lib/utils/jsonAdapter.ts
@@ -1,111 +1,98 @@
 import type { ParseError } from "jsonc-parser";
 import { FileFormat } from "../../enums/file.enum";
 
-export const contentToJson = (
+export const contentToJson = async (
   value: string,
   format = FileFormat.JSON,
 ): Promise<object> => {
-  return new Promise(async (resolve, reject) => {
-    try {
-      if (!value) return resolve({});
+  if (!value) return {};
 
-      if (format === FileFormat.JSON) {
-        const { parse } = await import("jsonc-parser");
-        const errors: ParseError[] = [];
-        const result = parse(value, errors);
-        if (errors.length > 0) JSON.parse(value);
-        return resolve(result);
-      }
+  if (format === FileFormat.JSON) {
+    const { parse } = await import("jsonc-parser");
+    const errors: ParseError[] = [];
+    const result = parse(value, errors);
+    if (errors.length > 0) JSON.parse(value);
+    return result;
+  }
 
-      if (format === FileFormat.YAML) {
-        const { load } = await import("js-yaml");
-        return resolve(load(value) as object);
-      }
+  if (format === FileFormat.YAML) {
+    const { load } = await import("js-yaml");
+    return load(value) as object;
+  }
 
-      if (format === FileFormat.XML) {
-        const { XMLParser } = await import("fast-xml-parser");
-        const parser = new XMLParser({
-          attributeNamePrefix: "$",
-          ignoreAttributes: false,
-          allowBooleanAttributes: true,
-          parseAttributeValue: true,
-          trimValues: true,
-          parseTagValue: true,
-        });
-        return resolve(parser.parse(value));
-      }
+  if (format === FileFormat.XML) {
+    const { XMLParser } = await import("fast-xml-parser");
+    const parser = new XMLParser({
+      attributeNamePrefix: "$",
+      ignoreAttributes: false,
+      allowBooleanAttributes: true,
+      parseAttributeValue: true,
+      trimValues: true,
+      parseTagValue: true,
+    });
+    return parser.parse(value);
+  }
 
-      if (format === FileFormat.CSV) {
-        const { csv2json } = await import("json-2-csv");
-        const result = csv2json(value, {
-          trimFieldValues: true,
-          trimHeaderFields: true,
-          wrapBooleans: true,
-          excelBOM: true,
-        });
-        return resolve(result);
-      }
+  if (format === FileFormat.CSV) {
+    const { csv2json } = await import("json-2-csv");
+    return csv2json(value, {
+      trimFieldValues: true,
+      trimHeaderFields: true,
+      wrapBooleans: true,
+      excelBOM: true,
+    });
+  }
 
-      return resolve({});
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to parse content";
-      return reject(errorMessage);
-    }
-  });
+  return {};
 };
 
 export const jsonToContent = async (
   json: string,
   format: FileFormat,
 ): Promise<string> => {
-  return new Promise(async (resolve) => {
-    try {
-      if (!json) return resolve("");
+  if (!json) return "";
 
-      if (format === FileFormat.JSON) {
-        const parsedJson = JSON.parse(json);
-        return resolve(JSON.stringify(parsedJson, null, 2));
-      }
-
-      if (format === FileFormat.YAML) {
-        const { dump } = await import("js-yaml");
-        const { parse } = await import("jsonc-parser");
-        return resolve(dump(parse(json)));
-      }
-
-      if (format === FileFormat.XML) {
-        const { XMLBuilder } = await import("fast-xml-parser");
-        const builder = new XMLBuilder({
-          format: true,
-          attributeNamePrefix: "$",
-          ignoreAttributes: false,
-        });
-
-        return resolve(builder.build(JSON.parse(json)));
-      }
-
-      if (format === FileFormat.CSV) {
-        const { json2csv } = await import("json-2-csv");
-        const parsedJson = JSON.parse(json);
-
-        const data = Array.isArray(parsedJson) ? parsedJson : [parsedJson];
-        return resolve(
-          json2csv(data, {
-            expandArrayObjects: true,
-            expandNestedObjects: true,
-            excelBOM: true,
-            wrapBooleans: true,
-            trimFieldValues: true,
-            trimHeaderFields: true,
-          }),
-        );
-      }
-
-      return resolve(json);
-    } catch (error) {
-      console.error(json, error);
-      return resolve(json);
+  try {
+    if (format === FileFormat.JSON) {
+      const parsedJson = JSON.parse(json);
+      return JSON.stringify(parsedJson, null, 2);
     }
-  });
+
+    if (format === FileFormat.YAML) {
+      const { dump } = await import("js-yaml");
+      const { parse } = await import("jsonc-parser");
+      return dump(parse(json));
+    }
+
+    if (format === FileFormat.XML) {
+      const { XMLBuilder } = await import("fast-xml-parser");
+      const builder = new XMLBuilder({
+        format: true,
+        attributeNamePrefix: "$",
+        ignoreAttributes: false,
+      });
+
+      return builder.build(JSON.parse(json));
+    }
+
+    if (format === FileFormat.CSV) {
+      const { json2csv } = await import("json-2-csv");
+      const parsedJson = JSON.parse(json);
+
+      const data = Array.isArray(parsedJson) ? parsedJson : [parsedJson];
+      return json2csv(data, {
+        expandArrayObjects: true,
+        expandNestedObjects: true,
+        excelBOM: true,
+        wrapBooleans: true,
+        trimFieldValues: true,
+        trimHeaderFields: true,
+      });
+    }
+
+    return json;
+  } catch (error) {
+    console.error(json, error);
+    return json;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -107,11 +107,5 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "packageManager": "pnpm@11.5.2",
-  "pnpm": {
-    "overrides": {
-      "minimatch": "3.1.2",
-      "axios": "^1.16.0"
-    }
-  }
+  "packageManager": "pnpm@11.5.2"
 }

--- a/scripts/skip-report.js
+++ b/scripts/skip-report.js
@@ -113,8 +113,10 @@ function parseJsonc(content) {
     s = s.replace(/,\s*(?=[}\]])/g, "");
     return JSON.parse(s);
   } catch (err) {
-    // propagate original error
-    throw err;
+    // rethrow with context, preserving original error as cause
+    const wrapped = new Error(`skip-report JSON parse error: ${err.message}`);
+    wrapped.cause = err;
+    throw wrapped;
   }
 }
 


### PR DESCRIPTION
## Summary

Comprehensive audit of uncommitted changes + Dependabot/CodeQL findings with fixes.

### 🔴 Critical Security Fixes
- **Upgrade `axios` from `0.30.3` → `^1.16.1`** in `frontend/dashboard/package.json` — the pinned version had 7+ known CVEs
- **Remove dangerous `pnpm.overrides`** in `frontend/dashboard/package.json` that was **pinning axios to `0.30.3`** (overriding the workspace security override)
- **Upgrade `axios` from `^1.7.9` → `^1.16.1`** in `examples/mesh-gateway/package.json`  
- **Upgrade `@apollo/server` from `^4.11.0` → `^4.13.0`** in examples/mesh-gateway (Dependabot #589)
- **Upgrade `ajv` from `8.17.1` → `^8.18.0`** in `converters/cli/package.json` (ReDoS CVE, Dependabot #603)
- **Remove deprecated `pnpm.overrides` from root `package.json`** — pnpm shows a warning that this field is ignored; overrides live in `pnpm-workspace.yaml`

### Dependabot Configuration Fix
The root cause of the Dependabot mismatch: **Dependabot was only scanning the root `/` directory**, so it read `package.json` version declarations (e.g., `axios: "0.30.3"`) without understanding pnpm workspace overrides. Expanding `.github/dependabot.yml` to cover all workspace packages + Cargo + GitHub Actions.

### CodeQL Fix
- **`converter.ts` `formatDescription()`**: Fixed incomplete string escaping (alerts #62, #63). Backslashes are now escaped before quotes, preventing injection via `\` + `"` sequences in GraphQL descriptions.

### Code Quality (from uncommitted changes review)
- **`jsonAdapter.ts`**: Removed `new Promise(async ...)` anti-pattern — errors now propagate naturally as Error objects instead of being stringified
- **`converter.ts`**: Removed unused `options` parameter from `convertGraphQLTypeToJsonSchema`
- **`skip-report.js`**: Improved error wrapping to preserve original error as `cause`
- **`.gitignore`**: Added `**/coverage/` to prevent tracking coverage reports
- **`.prettierignore`**: Added `**/salvaged/**/wasm/`

### Reverted Unsafe Change
- **`CodeMirrorEditor.jsx`**: The uncommitted change removed `JsonEditor` from `VisualJson` children (passing `null` instead). Since `VisualJsonProps` declares `children: ReactNode` (required), this would break the provider/editor composition. Restored the original `VisualJson && JsonEditor` check with proper child composition.

### Dependabot/CodeQL Alert Impact

| Alert | Package | Status |
|-------|---------|--------|
| #590-#602 | axios CVEs | ✅ Fixed — dashboard upgraded, overrides corrected |
| #603 | ajv ReDoS | ✅ Fixed — upgraded to ^8.18.0 |
| #589 | @apollo/server XSS | ✅ Fixed — upgraded to ^4.13.0 |
| #62, #63 | Incomplete string escaping | ✅ Fixed — backslash escaping added |
| #78 | XSS in coverage/lcov-report | ⚪ Tracked file, will be gitignored |
| #575-#577 | serialize-javascript | ⚪ Transitive dep, covered by workspace override |

