### PR TITLE
feat: transplant P1 analysis and DDL features

### DIFF
--- a/converters/rust/src/analysis/coverage.rs
+++ b/converters/rust/src/analysis/coverage.rs
@@ -1,0 +1,338 @@
+//! Coverage analysis for schema-to-schema mapping.
+//!
+//! Computes what percentage of a source schema's fields have
+//! corresponding fields in a target schema. Supports per-type
+//! coverage reports.
+
+use super::compute_stats;
+use serde_json::Value;
+use std::collections::HashSet;
+
+/// Coverage report for a single type.
+#[derive(Debug, Clone, Default)]
+pub struct TypeCoverage {
+    pub type_name: String,
+    pub total_source_fields: usize,
+    pub mapped_fields: usize,
+    pub missing_fields: Vec<String>,
+    pub coverage_percent: f64,
+}
+
+/// Overall coverage report.
+#[derive(Debug, Clone, Default)]
+pub struct CoverageReport {
+    pub type_coverages: Vec<TypeCoverage>,
+    pub total_source_fields: usize,
+    pub total_mapped_fields: usize,
+    pub overall_coverage_percent: f64,
+}
+
+impl CoverageReport {
+    /// Coverage is "complete" if all source fields are mapped.
+    pub fn is_complete(&self) -> bool {
+        self.total_mapped_fields == self.total_source_fields
+    }
+}
+
+/// Map entry describing a field mapping.
+#[derive(Debug, Clone)]
+pub struct FieldMapping {
+    pub source_type: String,
+    pub source_field: String,
+    pub target_type: String,
+    pub target_field: String,
+}
+
+/// Compute coverage between a source schema and a target schema
+/// based on a set of field mappings.
+pub fn compute_coverage(
+    source_schema: &Value,
+    target_schema: &Value,
+    mappings: &[FieldMapping],
+) -> CoverageReport {
+    let source_stats = compute_stats(source_schema);
+    let mut report = CoverageReport::default();
+
+    // Build set of mapped source field paths
+    let mut mapped_paths: HashSet<String> = HashSet::new();
+    for m in mappings {
+        mapped_paths.insert(format!("{}.{}", m.source_type, m.source_field));
+    }
+
+    // Per-type coverage
+    for def_stats in &source_stats.definitions {
+        let properties: Vec<String> = source_schema
+            .as_object()
+            .and_then(|o| o.get("$defs").or_else(|| o.get("definitions")))
+            .and_then(|d| d.as_object())
+            .and_then(|d| d.get(&def_stats.name))
+            .and_then(|d| d.as_object())
+            .and_then(|o| o.get("properties"))
+            .and_then(|p| p.as_object())
+            .map(|p| p.keys().cloned().collect())
+            .unwrap_or_default();
+
+        let total = properties.len();
+        let mut mapped = 0;
+        let mut missing: Vec<String> = vec![];
+
+        for prop in &properties {
+            let path = format!("{}.{}", def_stats.name, prop);
+            if mapped_paths.contains(&path) {
+                mapped += 1;
+            } else {
+                missing.push(prop.clone());
+            }
+        }
+
+        let coverage_percent = if total > 0 {
+            (mapped as f64 / total as f64) * 100.0
+        } else {
+            100.0
+        };
+
+        report.total_source_fields += total;
+        report.total_mapped_fields += mapped;
+        report.type_coverages.push(TypeCoverage {
+            type_name: def_stats.name.clone(),
+            total_source_fields: total,
+            mapped_fields: mapped,
+            missing_fields: missing,
+            coverage_percent,
+        });
+    }
+
+    report.overall_coverage_percent = if report.total_source_fields > 0 {
+        (report.total_mapped_fields as f64 / report.total_source_fields as f64) * 100.0
+    } else {
+        100.0
+    };
+
+    // Note: target_schema could be used for inverse coverage or
+    // additional metrics, but it's accepted for symmetry with
+    // other analysis functions.
+    let _ = target_schema;
+
+    report
+}
+
+/// Simpler coverage computation from raw schemas (avoids the
+/// function above's stub). Computes coverage of source fields
+/// that are present in target by name (camel/snake case aware).
+pub fn compute_field_coverage_by_name(
+    source_schema: &Value,
+    target_schema: &Value,
+) -> CoverageReport {
+    let source_defs = extract_defs(source_schema);
+    let target_defs = extract_defs(target_schema);
+
+    // Build set of (type, field) pairs in target
+    let mut target_field_paths: HashSet<String> = HashSet::new();
+    for (type_name, def_value) in &target_defs {
+        if let Some(obj) = def_value.as_object() {
+            if let Some(properties) = obj.get("properties").and_then(|p| p.as_object()) {
+                for field_name in properties.keys() {
+                    target_field_paths.insert(format!("{}.{}", type_name, field_name));
+                }
+            }
+        }
+    }
+
+    let mut report = CoverageReport::default();
+
+    for (type_name, def_value) in &source_defs {
+        let obj = match def_value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        let properties: Vec<String> = obj
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .map(|p| p.keys().cloned().collect())
+            .unwrap_or_default();
+
+        let total = properties.len();
+        let mut mapped = 0;
+        let mut missing: Vec<String> = vec![];
+
+        for prop in &properties {
+            let path = format!("{}.{}", type_name, prop);
+            if target_field_paths.contains(&path) {
+                mapped += 1;
+            } else {
+                missing.push(prop.clone());
+            }
+        }
+
+        let coverage_percent = if total > 0 {
+            (mapped as f64 / total as f64) * 100.0
+        } else {
+            100.0
+        };
+
+        report.total_source_fields += total;
+        report.total_mapped_fields += mapped;
+        report.type_coverages.push(TypeCoverage {
+            type_name: type_name.clone(),
+            total_source_fields: total,
+            mapped_fields: mapped,
+            missing_fields: missing,
+            coverage_percent,
+        });
+    }
+
+    report.overall_coverage_percent = if report.total_source_fields > 0 {
+        (report.total_mapped_fields as f64 / report.total_source_fields as f64) * 100.0
+    } else {
+        100.0
+    };
+
+    report
+}
+
+fn extract_defs(schema: &Value) -> std::collections::HashMap<String, Value> {
+    let obj = match schema.as_object() {
+        Some(o) => o,
+        None => return std::collections::HashMap::new(),
+    };
+    let defs = obj
+        .get("$defs")
+        .or_else(|| obj.get("definitions"))
+        .and_then(|d| d.as_object())
+        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
+    defs.unwrap_or_default()
+}
+
+/// Format a coverage report as a human-readable summary.
+pub fn format_coverage_report(report: &CoverageReport) -> String {
+    let mut lines: Vec<String> = vec![];
+    lines.push(format!(
+        "Coverage: {:.1}% ({}/{} fields mapped)",
+        report.overall_coverage_percent, report.total_mapped_fields, report.total_source_fields
+    ));
+    lines.push(String::new());
+    for tc in &report.type_coverages {
+        let status = if tc.coverage_percent >= 100.0 {
+            "✓"
+        } else if tc.coverage_percent >= 80.0 {
+            "○"
+        } else {
+            "✗"
+        };
+        lines.push(format!(
+            "  {} {}: {:.1}% ({}/{})",
+            status, tc.type_name, tc.coverage_percent, tc.mapped_fields, tc.total_source_fields
+        ));
+        if !tc.missing_fields.is_empty() {
+            lines.push(format!("    Missing: {}", tc.missing_fields.join(", ")));
+        }
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_full_coverage() {
+        let source = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let target = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let report = compute_field_coverage_by_name(&source, &target);
+        assert_eq!(report.overall_coverage_percent, 100.0);
+        assert!(report.is_complete());
+    }
+
+    #[test]
+    fn test_partial_coverage() {
+        let source = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"},
+                        "email": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let target = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let report = compute_field_coverage_by_name(&source, &target);
+        assert!(!report.is_complete());
+        assert!(report.overall_coverage_percent < 100.0);
+        assert!(report.type_coverages[0]
+            .missing_fields
+            .contains(&"name".to_string()));
+        assert!(report.type_coverages[0]
+            .missing_fields
+            .contains(&"email".to_string()));
+    }
+
+    #[test]
+    fn test_format_coverage_report() {
+        let source = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "missing_field": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let target = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}}
+                }
+            }
+        });
+        let report = compute_field_coverage_by_name(&source, &target);
+        let summary = format_coverage_report(&report);
+        assert!(summary.contains("Coverage:"));
+        assert!(summary.contains("Missing:"));
+        assert!(summary.contains("missing_field"));
+    }
+
+    #[test]
+    fn test_empty_schema_coverage() {
+        let source = json!({});
+        let target = json!({});
+        let report = compute_field_coverage_by_name(&source, &target);
+        assert_eq!(report.overall_coverage_percent, 100.0);
+    }
+}

--- a/converters/rust/src/analysis/diff.rs
+++ b/converters/rust/src/analysis/diff.rs
@@ -1,0 +1,388 @@
+//! Schema diff engine.
+//!
+//! Compares two JSON Schemas and reports differences in types,
+//! fields, and metadata.
+
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+/// Severity of a schema difference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DiffSeverity {
+    /// Type or field added (informational)
+    Added,
+    /// Type or field removed (potential breaking change)
+    Removed,
+    /// Type or field changed in a non-breaking way
+    Modified,
+}
+
+/// Category of schema difference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DiffCategory {
+    Type,
+    Field,
+    FieldType,
+    FieldRequired,
+    Federation,
+    Metadata,
+}
+
+/// A single schema difference.
+#[derive(Debug, Clone)]
+pub struct Diff {
+    pub category: DiffCategory,
+    pub severity: DiffSeverity,
+    pub path: String,
+    pub message: String,
+}
+
+/// Overall diff result.
+#[derive(Debug, Clone, Default)]
+pub struct DiffResult {
+    pub diffs: Vec<Diff>,
+    pub breaking_changes: usize,
+    pub non_breaking_changes: usize,
+}
+
+impl DiffResult {
+    pub fn is_compatible(&self) -> bool {
+        self.breaking_changes == 0
+    }
+
+    pub fn total(&self) -> usize {
+        self.diffs.len()
+    }
+}
+
+/// Compare two JSON Schemas and return differences.
+///
+/// Uses $defs/definitions as the comparison basis.
+pub fn diff_schemas(old: &Value, new: &Value) -> DiffResult {
+    let mut diffs = Vec::new();
+    let old_defs = extract_defs_map(old);
+    let new_defs = extract_defs_map(new);
+
+    let old_names: HashSet<&String> = old_defs.keys().collect();
+    let new_names: HashSet<&String> = new_defs.keys().collect();
+
+    // Added types
+    for added in new_names.difference(&old_names) {
+        diffs.push(Diff {
+            category: DiffCategory::Type,
+            severity: DiffSeverity::Added,
+            path: format!("$.$defs.{}", added),
+            message: format!("Type '{}' was added", added),
+        });
+    }
+
+    // Removed types
+    for removed in old_names.difference(&new_names) {
+        diffs.push(Diff {
+            category: DiffCategory::Type,
+            severity: DiffSeverity::Removed,
+            path: format!("$.$defs.{}", removed),
+            message: format!("Type '{}' was removed", removed),
+        });
+    }
+
+    // Modified types
+    for common in old_names.intersection(&new_names) {
+        let old_def = &old_defs[*common];
+        let new_def = &new_defs[*common];
+        diff_type_definition(common, old_def, new_def, &mut diffs);
+    }
+
+    // Compute severity counts
+    let breaking = diffs
+        .iter()
+        .filter(|d| matches!(d.severity, DiffSeverity::Removed))
+        .count();
+    let non_breaking = diffs
+        .iter()
+        .filter(|d| !matches!(d.severity, DiffSeverity::Removed))
+        .count();
+
+    DiffResult {
+        diffs,
+        breaking_changes: breaking,
+        non_breaking_changes: non_breaking,
+    }
+}
+
+fn extract_defs_map(schema: &Value) -> HashMap<String, Value> {
+    let obj = match schema.as_object() {
+        Some(o) => o,
+        None => return HashMap::new(),
+    };
+    let defs = obj
+        .get("$defs")
+        .or_else(|| obj.get("definitions"))
+        .and_then(|d| d.as_object())
+        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
+    defs.unwrap_or_default()
+}
+
+fn diff_type_definition(name: &str, old: &Value, new: &Value, diffs: &mut Vec<Diff>) {
+    let old_obj = match old.as_object() {
+        Some(o) => o,
+        None => return,
+    };
+    let new_obj = match new.as_object() {
+        Some(o) => o,
+        None => return,
+    };
+
+    // Check kind change
+    let old_kind = old_obj
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let new_kind = new_obj
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    if old_kind != new_kind {
+        diffs.push(Diff {
+            category: DiffCategory::FieldType,
+            severity: DiffSeverity::Modified,
+            path: format!("$.$defs.{}.type", name),
+            message: format!(
+                "Type '{}' changed kind: '{}' → '{}'",
+                name, old_kind, new_kind
+            ),
+        });
+    }
+
+    // Check field additions/removals
+    let old_props: HashSet<String> = old_obj
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .map(|p| p.keys().cloned().collect())
+        .unwrap_or_default();
+    let new_props: HashSet<String> = new_obj
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .map(|p| p.keys().cloned().collect())
+        .unwrap_or_default();
+
+    for added in new_props.difference(&old_props) {
+        diffs.push(Diff {
+            category: DiffCategory::Field,
+            severity: DiffSeverity::Added,
+            path: format!("$.$defs.{}.properties.{}", name, added),
+            message: format!("Type '{}': field '{}' was added", name, added),
+        });
+    }
+
+    for removed in old_props.difference(&new_props) {
+        diffs.push(Diff {
+            category: DiffCategory::Field,
+            severity: DiffSeverity::Removed,
+            path: format!("$.$defs.{}.properties.{}", name, removed),
+            message: format!("Type '{}': field '{}' was removed", name, removed),
+        });
+    }
+
+    // Check required field changes
+    let old_required: HashSet<String> = old_obj
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let new_required: HashSet<String> = new_obj
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Required → optional (non-breaking)
+    for optional in old_required.difference(&new_required) {
+        if new_props.contains(optional) {
+            diffs.push(Diff {
+                category: DiffCategory::FieldRequired,
+                severity: DiffSeverity::Modified,
+                path: format!("$.$defs.{}.required", name),
+                message: format!("Type '{}': field '{}' is now optional", name, optional),
+            });
+        }
+    }
+
+    // Optional → required (breaking for clients)
+    for required in new_required.difference(&old_required) {
+        diffs.push(Diff {
+            category: DiffCategory::FieldRequired,
+            severity: DiffSeverity::Removed,
+            path: format!("$.$defs.{}.required", name),
+            message: format!(
+                "Type '{}': field '{}' is now required (breaking change)",
+                name, required
+            ),
+        });
+    }
+
+    // Federation key changes
+    let old_fed = old_obj.contains_key("x-graphql-federation-keys")
+        || old_obj.contains_key("x-graphql-federation-key");
+    let new_fed = new_obj.contains_key("x-graphql-federation-keys")
+        || new_obj.contains_key("x-graphql-federation-key");
+
+    if old_fed && !new_fed {
+        diffs.push(Diff {
+            category: DiffCategory::Federation,
+            severity: DiffSeverity::Removed,
+            path: format!("$.$defs.{}.x-graphql-federation-keys", name),
+            message: format!(
+                "Type '{}': federation key was removed (breaking change)",
+                name
+            ),
+        });
+    }
+}
+
+/// Generate a human-readable summary of a diff.
+pub fn format_diff_summary(result: &DiffResult) -> String {
+    let mut lines: Vec<String> = vec![];
+    lines.push(format!("Schema diff: {} total changes", result.total()));
+    lines.push(format!("  Breaking changes: {}", result.breaking_changes));
+    lines.push(format!(
+        "  Non-breaking changes: {}",
+        result.non_breaking_changes
+    ));
+    lines.push(String::new());
+    for diff in &result.diffs {
+        let marker = match diff.severity {
+            DiffSeverity::Added => "+",
+            DiffSeverity::Removed => "-",
+            DiffSeverity::Modified => "~",
+        };
+        lines.push(format!("[{}] {}: {}", marker, diff.path, diff.message));
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_no_diff_identical() {
+        let schema = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}}
+                }
+            }
+        });
+        let result = diff_schemas(&schema, &schema);
+        assert_eq!(result.total(), 0);
+    }
+
+    #[test]
+    fn test_added_type() {
+        let old = json!({"$defs": {"User": {"type": "object"}}});
+        let new = json!({
+            "$defs": {
+                "User": {"type": "object"},
+                "Order": {"type": "object"}
+            }
+        });
+        let result = diff_schemas(&old, &new);
+        assert!(result
+            .diffs
+            .iter()
+            .any(|d| d.message.contains("Order") && matches!(d.severity, DiffSeverity::Added)));
+    }
+
+    #[test]
+    fn test_removed_type_breaking() {
+        let old = json!({
+            "$defs": {
+                "User": {"type": "object"},
+                "Order": {"type": "object"}
+            }
+        });
+        let new = json!({"$defs": {"User": {"type": "object"}}});
+        let result = diff_schemas(&old, &new);
+        assert_eq!(result.breaking_changes, 1);
+        assert!(!result.is_compatible());
+    }
+
+    #[test]
+    fn test_added_field_non_breaking() {
+        let old = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}}
+                }
+            }
+        });
+        let new = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let result = diff_schemas(&old, &new);
+        assert!(result.is_compatible());
+        assert!(result
+            .diffs
+            .iter()
+            .any(|d| d.message.contains("name") && matches!(d.severity, DiffSeverity::Added)));
+    }
+
+    #[test]
+    fn test_required_change_breaking() {
+        let old = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {"id": {"type": "string"}}
+                }
+            }
+        });
+        let new = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "required": ["id", "email"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "email": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let result = diff_schemas(&old, &new);
+        // Adding new field and making it required is breaking
+        assert!(!result.is_compatible());
+    }
+
+    #[test]
+    fn test_format_diff_summary() {
+        let old = json!({"$defs": {"A": {"type": "object"}}});
+        let new = json!({"$defs": {"B": {"type": "object"}}});
+        let result = diff_schemas(&old, &new);
+        let summary = format_diff_summary(&result);
+        assert!(summary.contains("Breaking changes"));
+        assert!(summary.contains("Type 'A' was removed"));
+        assert!(summary.contains("Type 'B' was added"));
+    }
+}

--- a/converters/rust/src/analysis/mod.rs
+++ b/converters/rust/src/analysis/mod.rs
@@ -1,0 +1,341 @@
+//! Schema analysis module.
+//!
+//! Computes statistics, structural metrics, reference graphs,
+//! diffs, and coverage reports for JSON Schemas. Used for schema
+//! governance, multi-source unification, and CI/CD validation.
+
+pub mod coverage;
+pub mod diff;
+
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+/// Statistics for a single definition in a JSON Schema.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DefinitionStats {
+    pub name: String,
+    pub kind: String, // object, array, string, number, etc.
+    pub field_count: usize,
+    pub required_count: usize,
+    pub nullable_count: usize,
+    pub description: Option<String>,
+    pub has_federation_key: bool,
+    pub has_skip_fields: bool,
+}
+
+/// Summary statistics for a JSON Schema.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SchemaStats {
+    /// Total number of definitions in $defs/definitions
+    pub total_definitions: usize,
+    /// Definitions grouped by kind (object, array, enum, etc.)
+    pub by_kind: HashMap<String, usize>,
+    /// Per-definition statistics
+    pub definitions: Vec<DefinitionStats>,
+    /// Total field count across all object definitions
+    pub total_fields: usize,
+    /// Maximum nesting depth observed
+    pub max_depth: usize,
+    /// Definitions with federation keys
+    pub federated_types: Vec<String>,
+    /// All field names across all object types
+    pub all_field_names: HashSet<String>,
+    /// Number of unique field names
+    pub unique_field_count: usize,
+    /// Total $ref count
+    pub ref_count: usize,
+}
+
+/// Compute statistics for a JSON Schema.
+pub fn compute_stats(schema: &Value) -> SchemaStats {
+    let mut stats = SchemaStats::default();
+    let obj = match schema.as_object() {
+        Some(o) => o,
+        None => return stats,
+    };
+
+    let defs = obj
+        .get("$defs")
+        .or_else(|| obj.get("definitions"))
+        .and_then(|d| d.as_object());
+
+    let defs_obj = match defs {
+        Some(d) => d,
+        None => return stats,
+    };
+
+    stats.total_definitions = defs_obj.len();
+
+    for (name, def_schema) in defs_obj {
+        let def_stats = compute_definition_stats(name, def_schema);
+        *stats.by_kind.entry(def_stats.kind.clone()).or_insert(0) += 1;
+        stats.total_fields += def_stats.field_count;
+        if def_stats.has_federation_key {
+            stats.federated_types.push(name.clone());
+        }
+        for field_name in collect_field_names(def_schema) {
+            stats.all_field_names.insert(field_name);
+        }
+        stats.definitions.push(def_stats);
+    }
+
+    stats.unique_field_count = stats.all_field_names.len();
+    stats.ref_count = count_refs(schema);
+    stats.max_depth = compute_max_depth(schema, 0);
+
+    stats
+}
+
+fn compute_definition_stats(name: &str, def_schema: &Value) -> DefinitionStats {
+    let mut stats = DefinitionStats {
+        name: name.to_string(),
+        ..Default::default()
+    };
+
+    if let Value::Object(obj) = def_schema {
+        stats.description = obj
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        // Determine kind
+        stats.kind = determine_kind(obj);
+
+        // Federation key presence
+        stats.has_federation_key = obj.contains_key("x-graphql-federation-keys")
+            || obj.contains_key("x-graphql-federation-key")
+            || obj
+                .get("x-graphql-federation")
+                .and_then(|f| f.as_object())
+                .is_some_and(|f| f.contains_key("keys"));
+
+        // Field-level stats
+        if let Some(properties) = obj.get("properties").and_then(|p| p.as_object()) {
+            stats.field_count = properties.len();
+            let required = obj
+                .get("required")
+                .and_then(|r| r.as_array())
+                .map(|arr| arr.len())
+                .unwrap_or(0);
+            stats.required_count = required;
+
+            // Count nullable (non-required) fields
+            stats.nullable_count = properties.len().saturating_sub(required);
+
+            // Skip field check
+            stats.has_skip_fields = properties
+                .iter()
+                .any(|(_, v)| v.get("x-graphql-skip").and_then(|s| s.as_bool()) == Some(true));
+        }
+    }
+
+    stats
+}
+
+fn determine_kind(obj: &serde_json::Map<String, Value>) -> String {
+    // x-graphql-type-kind takes precedence
+    if let Some(kind) = obj.get("x-graphql-type-kind").and_then(|v| v.as_str()) {
+        return kind.to_string();
+    }
+    // x-graphql-enum indicates enum
+    if obj.contains_key("x-graphql-enum") {
+        return "ENUM".to_string();
+    }
+    // x-graphql-scalar indicates scalar
+    if obj.contains_key("x-graphql-scalar") {
+        return "SCALAR".to_string();
+    }
+    // x-graphql-union indicates union
+    if obj.contains_key("x-graphql-union") {
+        return "UNION".to_string();
+    }
+    // Standard JSON Schema type
+    if let Some(t) = obj.get("type") {
+        match t {
+            Value::String(s) => return s.to_uppercase(),
+            Value::Array(arr) => {
+                if let Some(first) = arr.iter().find(|v| v.as_str() != Some("null")) {
+                    if let Some(s) = first.as_str() {
+                        return s.to_uppercase();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    "UNKNOWN".to_string()
+}
+
+fn collect_field_names(def_schema: &Value) -> HashSet<String> {
+    let mut names = HashSet::new();
+    if let Value::Object(obj) = def_schema {
+        if let Some(properties) = obj.get("properties").and_then(|p| p.as_object()) {
+            for key in properties.keys() {
+                names.insert(key.clone());
+            }
+        }
+    }
+    names
+}
+
+fn count_refs(schema: &Value) -> usize {
+    let mut count = 0;
+    count_refs_recursive(schema, &mut count);
+    count
+}
+
+fn count_refs_recursive(value: &Value, count: &mut usize) {
+    match value {
+        Value::Object(obj) => {
+            if obj.contains_key("$ref") {
+                *count += 1;
+            }
+            for v in obj.values() {
+                count_refs_recursive(v, count);
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                count_refs_recursive(v, count);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn compute_max_depth(value: &Value, current: usize) -> usize {
+    match value {
+        Value::Object(obj) => {
+            let mut max = current;
+            for v in obj.values() {
+                let d = compute_max_depth(v, current + 1);
+                if d > max {
+                    max = d;
+                }
+            }
+            max
+        }
+        Value::Array(arr) => {
+            let mut max = current;
+            for v in arr {
+                let d = compute_max_depth(v, current + 1);
+                if d > max {
+                    max = d;
+                }
+            }
+            max
+        }
+        _ => current,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_compute_stats_empty_schema() {
+        let schema = json!({});
+        let stats = compute_stats(&schema);
+        assert_eq!(stats.total_definitions, 0);
+        assert_eq!(stats.total_fields, 0);
+    }
+
+    #[test]
+    fn test_compute_stats_basic() {
+        let schema = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "description": "A user",
+                    "x-graphql-type-name": "User",
+                    "required": ["id"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"},
+                        "email": {"type": "string"}
+                    }
+                },
+                "Status": {
+                    "type": "string",
+                    "enum": ["ACTIVE", "INACTIVE"]
+                }
+            }
+        });
+        let stats = compute_stats(&schema);
+        assert_eq!(stats.total_definitions, 2);
+        assert_eq!(stats.total_fields, 3);
+        assert_eq!(stats.by_kind.get("OBJECT").copied().unwrap_or(0), 1);
+        assert_eq!(stats.by_kind.get("STRING").copied().unwrap_or(0), 1);
+    }
+
+    #[test]
+    fn test_federation_key_detection() {
+        let schema = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "x-graphql-federation-keys": ["id"]
+                },
+                "Order": {
+                    "type": "object",
+                    "x-graphql-federation": {
+                        "keys": ["orderId"]
+                    }
+                },
+                "Product": {
+                    "type": "object"
+                }
+            }
+        });
+        let stats = compute_stats(&schema);
+        assert_eq!(stats.federated_types.len(), 2);
+        assert!(stats.federated_types.contains(&"User".to_string()));
+        assert!(stats.federated_types.contains(&"Order".to_string()));
+    }
+
+    #[test]
+    fn test_unique_field_count() {
+        let schema = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"}
+                    }
+                },
+                "Order": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "total": {"type": "number"}
+                    }
+                }
+            }
+        });
+        let stats = compute_stats(&schema);
+        assert_eq!(stats.unique_field_count, 3); // id, name, total
+    }
+
+    #[test]
+    fn test_count_refs() {
+        let schema = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "address": {"$ref": "#/$defs/Address"},
+                        "orders": {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/Order"}
+                        }
+                    }
+                }
+            }
+        });
+        let stats = compute_stats(&schema);
+        assert_eq!(stats.ref_count, 2);
+    }
+}

--- a/converters/rust/src/ddl/mod.rs
+++ b/converters/rust/src/ddl/mod.rs
@@ -1,0 +1,586 @@
+//! Schema → Relational DDL pipeline.
+//!
+//! Decomposes a JSON Schema into relational tables and parent/child
+//! relations, then emits Spark/Delta-compatible `CREATE TABLE` DDL.
+//!
+//! Ported from TTSE-petrified-forest's `petrified_schema.relational`
+//! and `petrified_schema.ddl` Python modules.
+
+use serde_json::Value;
+use std::collections::HashSet;
+
+/// Definition of a single column in a table.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnDef {
+    pub name: String,
+    pub sql_type: String, // STRING, BIGINT, DOUBLE, BOOLEAN, TIMESTAMP, DATE
+    pub nullable: bool,
+    pub description: Option<String>,
+    pub enum_values: Option<Vec<String>>,
+}
+
+/// Definition of a single table.
+#[derive(Debug, Clone)]
+pub struct TableDef {
+    pub name: String,
+    pub columns: Vec<ColumnDef>,
+    pub primary_key: Option<String>,
+    pub description: Option<String>,
+}
+
+/// Parent/child relation: child table has FK column pointing to parent.
+#[derive(Debug, Clone)]
+pub struct RelationDef {
+    pub parent_table: String,
+    pub child_table: String,
+    pub fk_column: String,
+}
+
+/// Result of decomposing a schema into tables and relations.
+#[derive(Debug, Clone, Default)]
+pub struct RelationalSchema {
+    pub tables: Vec<TableDef>,
+    pub relations: Vec<RelationDef>,
+}
+
+/// Decompose a JSON Schema into relational tables.
+///
+/// Reads the schema's `root_def` definition (default: `contract`) and
+/// walks its object/array structure to produce tables and relations.
+///
+/// Objects become tables. Arrays of objects become child tables (1:N).
+/// Arrays of scalars become tables with `value` and `ordinal` columns.
+/// Nested objects become 1:1 child tables with FK.
+pub fn schema_to_relational(schema: &Value, root_def: &str) -> RelationalSchema {
+    let mut result = RelationalSchema::default();
+
+    let obj = match schema.as_object() {
+        Some(o) => o,
+        None => return result,
+    };
+
+    let defs = obj
+        .get("$defs")
+        .or_else(|| obj.get("definitions"))
+        .and_then(|d| d.as_object());
+
+    let defs_obj = match defs {
+        Some(d) => d,
+        None => return result,
+    };
+
+    let root_node = match defs_obj.get(root_def) {
+        Some(n) => n,
+        None => return result,
+    };
+
+    let required: HashSet<String> = root_node
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    walk_node(
+        root_node,
+        root_def,
+        &[root_def.to_string()],
+        &required,
+        &mut result,
+    );
+
+    // Ensure top-level FK relations are properly set up
+    result
+}
+
+/// Walk a schema node and produce tables/relations.
+///
+/// Returns the table name for this node (if it created a table) or None.
+fn walk_node(
+    node: &Value,
+    table_name: &str,
+    path: &[String],
+    required: &HashSet<String>,
+    result: &mut RelationalSchema,
+) -> Option<String> {
+    if !is_object(node) {
+        return None;
+    }
+
+    let obj = node.as_object().unwrap();
+    let mut columns: Vec<ColumnDef> = vec![];
+
+    let properties = obj.get("properties").and_then(|p| p.as_object());
+
+    if let Some(props) = properties {
+        for (prop_name, prop_schema) in props {
+            let prop_required = required.contains(prop_name);
+            let nullable = !prop_required;
+
+            if is_scalar_or_enum(prop_schema) {
+                let sql_type = map_json_type_to_sql(prop_schema);
+                let enum_values = get_enum_values(prop_schema);
+                let description = prop_schema
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                columns.push(ColumnDef {
+                    name: prop_name.clone(),
+                    sql_type,
+                    nullable,
+                    description,
+                    enum_values,
+                });
+            } else if is_object(prop_schema) {
+                // Nested object → child table (1:1)
+                let mut child_path = path.to_vec();
+                child_path.push(prop_name.clone());
+                let child_table_name = child_path.join("_");
+                let child_required: HashSet<String> = prop_schema
+                    .get("required")
+                    .and_then(|r| r.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                if let Some(child_table) = walk_node(
+                    prop_schema,
+                    &child_table_name,
+                    &child_path,
+                    &child_required,
+                    result,
+                ) {
+                    // Add FK column to child table
+                    let fk_col = format!("{}_id", table_name);
+                    result.relations.push(RelationDef {
+                        parent_table: table_name.to_string(),
+                        child_table: child_table.clone(),
+                        fk_column: fk_col.clone(),
+                    });
+
+                    // Add the FK column to the child table definition
+                    if let Some(td) = result.tables.iter_mut().find(|t| t.name == child_table) {
+                        // Only add if not already present
+                        if !td.columns.iter().any(|c| c.name == fk_col) {
+                            td.columns.insert(
+                                0,
+                                ColumnDef {
+                                    name: fk_col,
+                                    sql_type: "STRING".to_string(),
+                                    nullable: false,
+                                    description: Some("FK to parent".to_string()),
+                                    enum_values: None,
+                                },
+                            );
+                        }
+                    }
+                }
+            } else if is_array(prop_schema) {
+                // Array → child table (1:N)
+                let items = prop_schema.get("items");
+                if let Some(items) = items {
+                    let mut child_path = path.to_vec();
+                    child_path.push(prop_name.clone());
+                    let child_table_name = child_path.join("_");
+                    let fk_col = format!("{}_id", table_name);
+
+                    if is_scalar_or_enum(items) {
+                        // Array of scalars
+                        let sql_type = map_json_type_to_sql(items);
+                        result.tables.push(TableDef {
+                            name: child_table_name.clone(),
+                            columns: vec![
+                                ColumnDef {
+                                    name: fk_col.clone(),
+                                    sql_type: "STRING".to_string(),
+                                    nullable: false,
+                                    description: Some("FK to parent".to_string()),
+                                    enum_values: None,
+                                },
+                                ColumnDef {
+                                    name: "value".to_string(),
+                                    sql_type,
+                                    nullable: true,
+                                    description: None,
+                                    enum_values: None,
+                                },
+                                ColumnDef {
+                                    name: "ordinal".to_string(),
+                                    sql_type: "BIGINT".to_string(),
+                                    nullable: false,
+                                    description: None,
+                                    enum_values: None,
+                                },
+                            ],
+                            primary_key: None,
+                            description: prop_schema
+                                .get("description")
+                                .and_then(|v| v.as_str())
+                                .map(String::from),
+                        });
+                        result.relations.push(RelationDef {
+                            parent_table: table_name.to_string(),
+                            child_table: child_table_name,
+                            fk_column: fk_col,
+                        });
+                    } else if is_object(items) {
+                        // Array of objects
+                        let child_required: HashSet<String> = items
+                            .get("required")
+                            .and_then(|r| r.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str().map(String::from))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        if let Some(child_table) = walk_node(
+                            items,
+                            &child_table_name,
+                            &child_path,
+                            &child_required,
+                            result,
+                        ) {
+                            if let Some(td) =
+                                result.tables.iter_mut().find(|t| t.name == child_table)
+                            {
+                                if !td.columns.iter().any(|c| c.name == fk_col) {
+                                    td.columns.insert(
+                                        0,
+                                        ColumnDef {
+                                            name: fk_col.clone(),
+                                            sql_type: "STRING".to_string(),
+                                            nullable: false,
+                                            description: Some("FK to parent".to_string()),
+                                            enum_values: None,
+                                        },
+                                    );
+                                }
+                            }
+                            result.relations.push(RelationDef {
+                                parent_table: table_name.to_string(),
+                                child_table: child_table.clone(),
+                                fk_column: fk_col,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Infer primary key
+    let pk = infer_primary_key(&columns);
+    let description = obj
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    result.tables.push(TableDef {
+        name: table_name.to_string(),
+        columns,
+        primary_key: pk,
+        description,
+    });
+
+    Some(table_name.to_string())
+}
+
+fn is_object(v: &Value) -> bool {
+    v.get("type").and_then(|t| t.as_str()) == Some("object")
+        || (v.get("type").is_none() && v.get("properties").is_some())
+}
+
+fn is_array(v: &Value) -> bool {
+    v.get("type").and_then(|t| t.as_str()) == Some("array")
+}
+
+fn is_scalar_or_enum(v: &Value) -> bool {
+    let kind = v
+        .get("type")
+        .and_then(|t| t.as_str())
+        .or_else(|| {
+            // Handle type arrays like ["string", "null"]
+            v.get("type").and_then(|t| t.as_array()).and_then(|arr| {
+                arr.iter()
+                    .find(|t| t.as_str() != Some("null"))
+                    .and_then(|t| t.as_str())
+            })
+        })
+        .unwrap_or("");
+    matches!(
+        kind,
+        "string" | "number" | "integer" | "boolean" | "date-time" | "date" | "enum"
+    )
+}
+
+fn map_json_type_to_sql(v: &Value) -> String {
+    // Check for explicit format first
+    if let Some(format) = v.get("format").and_then(|f| f.as_str()) {
+        if format == "date-time" {
+            return "TIMESTAMP".to_string();
+        }
+        if format == "date" {
+            return "DATE".to_string();
+        }
+    }
+
+    // Check for enum
+    if v.get("enum").is_some() {
+        return "STRING".to_string();
+    }
+
+    let kind = v
+        .get("type")
+        .and_then(|t| t.as_str())
+        .or_else(|| {
+            v.get("type").and_then(|t| t.as_array()).and_then(|arr| {
+                arr.iter()
+                    .find(|t| t.as_str() != Some("null"))
+                    .and_then(|t| t.as_str())
+            })
+        })
+        .unwrap_or("string");
+
+    match kind {
+        "string" => "STRING".to_string(),
+        "integer" => "BIGINT".to_string(), // unbounded → BIGINT
+        "number" => "DOUBLE".to_string(),
+        "boolean" => "BOOLEAN".to_string(),
+        "date-time" => "TIMESTAMP".to_string(),
+        "date" => "DATE".to_string(),
+        _ => "STRING".to_string(),
+    }
+}
+
+fn get_enum_values(v: &Value) -> Option<Vec<String>> {
+    v.get("enum").and_then(|e| e.as_array()).map(|arr| {
+        arr.iter()
+            .filter_map(|x| match x {
+                Value::String(s) => Some(s.clone()),
+                Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .collect()
+    })
+}
+
+fn infer_primary_key(columns: &[ColumnDef]) -> Option<String> {
+    // Prefer non-nullable `id` or `global_record_id`
+    for preferred in &["id", "global_record_id"] {
+        if let Some(col) = columns.iter().find(|c| c.name == *preferred) {
+            if !col.nullable {
+                return Some(preferred.to_string());
+            }
+        }
+    }
+    // Otherwise, sole non-nullable column
+    let non_nullable: Vec<&ColumnDef> = columns.iter().filter(|c| !c.nullable).collect();
+    if non_nullable.len() == 1 {
+        Some(non_nullable[0].name.clone())
+    } else {
+        None
+    }
+}
+
+/// Generate Spark/Delta DDL for a relational schema.
+pub fn generate_ddl(schema: &RelationalSchema, using_delta: bool) -> String {
+    let mut out = String::new();
+
+    for table in &schema.tables {
+        out.push_str(&format!("CREATE TABLE IF NOT EXISTS {} (\n", table.name));
+        let col_strs: Vec<String> = table
+            .columns
+            .iter()
+            .map(|c| format!("  {} {}", c.name, c.sql_type,))
+            .collect();
+        out.push_str(&col_strs.join(",\n"));
+        out.push_str("\n)");
+
+        if using_delta {
+            out.push_str(" USING DELTA");
+        }
+        out.push_str(";\n\n");
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_schema_to_relational_simple() {
+        let schema = json!({
+            "$defs": {
+                "contract": {
+                    "type": "object",
+                    "description": "A contract",
+                    "required": ["id", "name"],
+                    "properties": {
+                        "id": {"type": "string", "format": "uuid"},
+                        "name": {"type": "string"},
+                        "amount": {"type": "number"}
+                    }
+                }
+            }
+        });
+        let rel = schema_to_relational(&schema, "contract");
+        assert_eq!(rel.tables.len(), 1);
+        assert_eq!(rel.tables[0].name, "contract");
+        assert_eq!(rel.tables[0].columns.len(), 3);
+        assert_eq!(rel.tables[0].primary_key, Some("id".to_string()));
+    }
+
+    #[test]
+    fn test_schema_to_relational_nested_object() {
+        let schema = json!({
+            "$defs": {
+                "contract": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "vendor": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                                "name": {"type": "string"},
+                                "uei": {"type": "string"}
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        let rel = schema_to_relational(&schema, "contract");
+        assert_eq!(rel.tables.len(), 2);
+        assert!(rel.tables.iter().any(|t| t.name == "contract"));
+        assert!(rel.tables.iter().any(|t| t.name == "contract_vendor"));
+        assert_eq!(rel.relations.len(), 1);
+        assert_eq!(rel.relations[0].parent_table, "contract");
+        assert_eq!(rel.relations[0].child_table, "contract_vendor");
+    }
+
+    #[test]
+    fn test_schema_to_relational_array_of_objects() {
+        let schema = json!({
+            "$defs": {
+                "contract": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "line_items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": ["amount"],
+                                "properties": {
+                                    "amount": {"type": "number"},
+                                    "description": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        let rel = schema_to_relational(&schema, "contract");
+        assert!(rel.tables.iter().any(|t| t.name == "contract_line_items"));
+    }
+
+    #[test]
+    fn test_schema_to_relational_array_of_scalars() {
+        let schema = json!({
+            "$defs": {
+                "contract": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        }
+                    }
+                }
+            }
+        });
+        let rel = schema_to_relational(&schema, "contract");
+        let tags_table = rel
+            .tables
+            .iter()
+            .find(|t| t.name == "contract_tags")
+            .unwrap();
+        // Should have FK, value, ordinal columns
+        assert!(tags_table.columns.iter().any(|c| c.name == "value"));
+        assert!(tags_table.columns.iter().any(|c| c.name == "ordinal"));
+    }
+
+    #[test]
+    fn test_map_json_type_to_sql() {
+        assert_eq!(map_json_type_to_sql(&json!({"type": "string"})), "STRING");
+        assert_eq!(map_json_type_to_sql(&json!({"type": "integer"})), "BIGINT");
+        assert_eq!(map_json_type_to_sql(&json!({"type": "number"})), "DOUBLE");
+        assert_eq!(map_json_type_to_sql(&json!({"type": "boolean"})), "BOOLEAN");
+        assert_eq!(
+            map_json_type_to_sql(&json!({"type": "string", "format": "date-time"})),
+            "TIMESTAMP"
+        );
+        assert_eq!(
+            map_json_type_to_sql(&json!({"type": "string", "format": "date"})),
+            "DATE"
+        );
+    }
+
+    #[test]
+    fn test_generate_ddl() {
+        let schema = json!({
+            "$defs": {
+                "User": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let rel = schema_to_relational(&schema, "User");
+        let ddl = generate_ddl(&rel, true);
+        assert!(ddl.contains("CREATE TABLE"));
+        assert!(ddl.contains("USING DELTA"));
+        assert!(ddl.contains("id STRING"));
+    }
+
+    #[test]
+    fn test_infer_primary_key() {
+        let columns = vec![
+            ColumnDef {
+                name: "id".to_string(),
+                sql_type: "STRING".to_string(),
+                nullable: false,
+                description: None,
+                enum_values: None,
+            },
+            ColumnDef {
+                name: "name".to_string(),
+                sql_type: "STRING".to_string(),
+                nullable: true,
+                description: None,
+                enum_values: None,
+            },
+        ];
+        assert_eq!(infer_primary_key(&columns), Some("id".to_string()));
+    }
+}

--- a/converters/rust/src/ddl/mod.rs
+++ b/converters/rust/src/ddl/mod.rs
@@ -2,9 +2,6 @@
 //!
 //! Decomposes a JSON Schema into relational tables and parent/child
 //! relations, then emits Spark/Delta-compatible `CREATE TABLE` DDL.
-//!
-//! Ported from TTSE-petrified-forest's `petrified_schema.relational`
-//! and `petrified_schema.ddl` Python modules.
 
 use serde_json::Value;
 use std::collections::HashSet;

--- a/converters/rust/src/diagram/mod.rs
+++ b/converters/rust/src/diagram/mod.rs
@@ -1,6 +1,4 @@
 //! Mermaid ER diagram generation from a relational schema.
-//!
-//! Ported from TTSE-petrified-forest's `petrified_schema.mermaid` module.
 
 use crate::ddl::{RelationDef, TableDef};
 

--- a/converters/rust/src/diagram/mod.rs
+++ b/converters/rust/src/diagram/mod.rs
@@ -1,0 +1,210 @@
+//! Mermaid ER diagram generation from a relational schema.
+//!
+//! Ported from TTSE-petrified-forest's `petrified_schema.mermaid` module.
+
+use crate::ddl::{RelationDef, TableDef};
+
+/// Sanitize a name for Mermaid entity (alphanumeric and underscore only).
+pub fn mermaid_entity_name(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    sanitized.trim_matches('_').to_string()
+}
+
+/// Ensure a type is valid for Mermaid (alphanumeric only).
+pub fn mermaid_type(t: &str) -> String {
+    // Normalize known compound types first
+    let normalized = match t {
+        "date-time" => "datetime".to_string(),
+        other => other.to_string(),
+    };
+    let sanitized: String = normalized
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    if !sanitized.is_empty() && sanitized.chars().next().is_some_and(|c| c.is_alphabetic()) {
+        sanitized
+    } else {
+        "string".to_string()
+    }
+}
+
+/// Build a Mermaid ER diagram string from tables and relations.
+pub fn to_mermaid_er(tables: &[TableDef], relations: &[RelationDef]) -> String {
+    let mut lines: Vec<String> = vec!["erDiagram".to_string()];
+    let entity_names: std::collections::HashMap<String, String> = tables
+        .iter()
+        .map(|t| (t.name.clone(), mermaid_entity_name(&t.name)))
+        .collect();
+
+    let fk_columns: std::collections::HashSet<(String, String)> = relations
+        .iter()
+        .map(|r| (r.child_table.clone(), r.fk_column.clone()))
+        .collect();
+
+    for table in tables {
+        let eid = entity_names
+            .get(&table.name)
+            .cloned()
+            .unwrap_or_else(|| mermaid_entity_name(&table.name));
+
+        if !table.columns.is_empty() {
+            lines.push(format!("    {} {{", eid));
+            for col in &table.columns {
+                let mut suffix = String::new();
+                if let Some(ref pk) = table.primary_key {
+                    if col.name == *pk {
+                        suffix = " PK".to_string();
+                    }
+                }
+                if fk_columns.contains(&(table.name.clone(), col.name.clone())) {
+                    suffix = " FK".to_string();
+                }
+                let mtype = mermaid_type(&col.sql_type);
+                lines.push(format!("        {} {}{}", mtype, col.name, suffix));
+            }
+            lines.push("    }".to_string());
+        } else {
+            lines.push(format!("    {}", eid));
+        }
+    }
+
+    for rel in relations {
+        let parent_id = entity_names
+            .get(&rel.parent_table)
+            .cloned()
+            .unwrap_or_else(|| mermaid_entity_name(&rel.parent_table));
+        let child_id = entity_names
+            .get(&rel.child_table)
+            .cloned()
+            .unwrap_or_else(|| mermaid_entity_name(&rel.child_table));
+        lines.push(format!(
+            "    {} ||--o{{ {} : \"{}\"",
+            parent_id, child_id, rel.fk_column
+        ));
+    }
+
+    lines.join("\n")
+}
+
+/// Build a full markdown document with the Mermaid ER diagram.
+pub fn to_mermaid_markdown(
+    tables: &[TableDef],
+    relations: &[RelationDef],
+    title: Option<&str>,
+) -> String {
+    let diagram = to_mermaid_er(tables, relations);
+    let mut parts: Vec<String> = vec![];
+
+    if let Some(t) = title {
+        parts.push(format!("# {}", t));
+        parts.push(String::new());
+    }
+
+    parts.push("```mermaid".to_string());
+    parts.push(diagram);
+    parts.push("```".to_string());
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ddl::{ColumnDef, RelationDef, TableDef};
+
+    fn sample_tables() -> Vec<TableDef> {
+        vec![
+            TableDef {
+                name: "contract".to_string(),
+                columns: vec![
+                    ColumnDef {
+                        name: "id".to_string(),
+                        sql_type: "STRING".to_string(),
+                        nullable: false,
+                        description: None,
+                        enum_values: None,
+                    },
+                    ColumnDef {
+                        name: "name".to_string(),
+                        sql_type: "STRING".to_string(),
+                        nullable: true,
+                        description: None,
+                        enum_values: None,
+                    },
+                ],
+                primary_key: Some("id".to_string()),
+                description: None,
+            },
+            TableDef {
+                name: "contract_vendor".to_string(),
+                columns: vec![
+                    ColumnDef {
+                        name: "contract_id".to_string(),
+                        sql_type: "STRING".to_string(),
+                        nullable: false,
+                        description: None,
+                        enum_values: None,
+                    },
+                    ColumnDef {
+                        name: "name".to_string(),
+                        sql_type: "STRING".to_string(),
+                        nullable: true,
+                        description: None,
+                        enum_values: None,
+                    },
+                ],
+                primary_key: None,
+                description: None,
+            },
+        ]
+    }
+
+    fn sample_relations() -> Vec<RelationDef> {
+        vec![RelationDef {
+            parent_table: "contract".to_string(),
+            child_table: "contract_vendor".to_string(),
+            fk_column: "contract_id".to_string(),
+        }]
+    }
+
+    #[test]
+    fn test_mermaid_entity_name() {
+        assert_eq!(mermaid_entity_name("contract-vendor"), "contract_vendor");
+        assert_eq!(mermaid_entity_name("simple"), "simple");
+        assert_eq!(mermaid_entity_name("_test_"), "test");
+    }
+
+    #[test]
+    fn test_mermaid_type() {
+        assert_eq!(mermaid_type("STRING"), "STRING");
+        assert_eq!(mermaid_type("date-time"), "datetime");
+        assert_eq!(mermaid_type("123_invalid"), "string");
+    }
+
+    #[test]
+    fn test_to_mermaid_er() {
+        let diagram = to_mermaid_er(&sample_tables(), &sample_relations());
+        assert!(diagram.contains("erDiagram"));
+        assert!(diagram.contains("contract"));
+        assert!(diagram.contains("contract_vendor"));
+        assert!(diagram.contains("||--o{"));
+        assert!(diagram.contains("PK"));
+        assert!(diagram.contains("FK"));
+    }
+
+    #[test]
+    fn test_to_mermaid_markdown() {
+        let md = to_mermaid_markdown(&sample_tables(), &sample_relations(), Some("Test Schema"));
+        assert!(md.contains("# Test Schema"));
+        assert!(md.contains("```mermaid"));
+        assert!(md.contains("erDiagram"));
+    }
+}

--- a/converters/rust/src/lib.rs
+++ b/converters/rust/src/lib.rs
@@ -28,6 +28,7 @@ pub mod analysis;
 pub mod api_types;
 pub mod case_conversion;
 pub mod ddl;
+pub mod diagram;
 pub mod error;
 pub mod graphql_ast_json;
 pub mod graphql_to_json;

--- a/converters/rust/src/lib.rs
+++ b/converters/rust/src/lib.rs
@@ -31,6 +31,7 @@ pub mod error;
 pub mod graphql_ast_json;
 pub mod graphql_to_json;
 pub mod json_to_graphql;
+pub mod mapping;
 #[cfg(feature = "graphql-server")]
 pub mod schema;
 pub mod types;

--- a/converters/rust/src/lib.rs
+++ b/converters/rust/src/lib.rs
@@ -27,6 +27,7 @@ pub mod analysis;
 #[cfg(any(feature = "graphql-server", feature = "wasm"))]
 pub mod api_types;
 pub mod case_conversion;
+pub mod ddl;
 pub mod error;
 pub mod graphql_ast_json;
 pub mod graphql_to_json;

--- a/converters/rust/src/lib.rs
+++ b/converters/rust/src/lib.rs
@@ -23,6 +23,7 @@
 //! let result = converter.convert(json_schema, ConversionDirection::JsonSchemaToGraphQL);
 //! ```
 
+pub mod analysis;
 #[cfg(any(feature = "graphql-server", feature = "wasm"))]
 pub mod api_types;
 pub mod case_conversion;

--- a/converters/rust/src/mapping/mod.rs
+++ b/converters/rust/src/mapping/mod.rs
@@ -1,0 +1,348 @@
+//! Field mapping system for multi-source schema unification.
+//!
+//! Maps fields between source systems and a canonical schema. Supports
+//! multiple candidate locations per field (JSON pointers) and pointer
+//! resolution that prefers mapped locations before falling back to
+//! direct resolution.
+//!
+//! Ported from TTSE-petrified-forest's `field-mapping-helper.mjs` and
+//! the `fieldMapping` parameter in `ir-to-graphql.mjs`.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::case_conversion::{camel_to_snake, snake_to_camel};
+
+/// Mapping entry for a single field in a source system.
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+pub struct FieldMappingEntry {
+    /// The field name as it appears in the source (snake_case)
+    #[serde(default)]
+    pub snake: Option<String>,
+    /// The field name as it appears in GraphQL (camelCase)
+    #[serde(default)]
+    pub camel: Option<String>,
+    /// Possible JSON pointer locations where this field may exist
+    /// (e.g., `/properties/contract_id` or `properties/contract_id`)
+    #[serde(default)]
+    pub locations: Vec<String>,
+}
+
+/// A field mapping indexed by GraphQL field name.
+pub type FieldMapping = HashMap<String, FieldMappingEntry>;
+
+/// Build a FieldMapping from a JSON object (e.g., loaded from
+/// `field-mapping.json`).
+pub fn parse_field_mapping(value: &Value) -> FieldMapping {
+    let mut map = FieldMapping::new();
+    if let Some(obj) = value.as_object() {
+        for (key, entry_value) in obj {
+            if let Some(entry_obj) = entry_value.as_object() {
+                let entry = FieldMappingEntry {
+                    snake: entry_obj
+                        .get("snake")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    camel: entry_obj
+                        .get("camel")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    locations: entry_obj
+                        .get("locations")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                };
+                map.insert(key.clone(), entry);
+            } else if let Some(locations) = entry_value.as_array() {
+                // Shorthand: just an array of locations
+                let entry = FieldMappingEntry {
+                    snake: None,
+                    camel: None,
+                    locations: locations
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect(),
+                };
+                map.insert(key.clone(), entry);
+            } else if let Some(s) = entry_value.as_str() {
+                // Even shorter: just a single location string
+                let entry = FieldMappingEntry {
+                    snake: None,
+                    camel: None,
+                    locations: vec![s.to_string()],
+                };
+                map.insert(key.clone(), entry);
+            }
+        }
+    }
+    map
+}
+
+/// Walk a JSON pointer path through a schema.
+///
+/// Accepts both `/foo/bar` and `foo/bar` formats. Tries direct
+/// key access, then camelCase/snake_case variants.
+pub fn resolve_pointer<'a>(schema: &'a Value, pointer: &str) -> Option<&'a Value> {
+    if pointer.is_empty() || pointer == "/" {
+        return Some(schema);
+    }
+
+    let parts: Vec<&str> = pointer
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|p| !p.is_empty())
+        .collect();
+
+    let mut current = schema;
+    for part in parts {
+        if let Some(obj) = current.as_object() {
+            // Direct match
+            if let Some(v) = obj.get(part) {
+                current = v;
+                continue;
+            }
+            // Snake case match
+            if let Some(v) = obj.get(camel_to_snake(part).as_str()) {
+                current = v;
+                continue;
+            }
+            // Camel case match
+            if let Some(v) = obj.get(snake_to_camel(part).as_str()) {
+                current = v;
+                continue;
+            }
+            return None;
+        } else {
+            let arr = current.as_array()?;
+            if let Ok(idx) = part.parse::<usize>() {
+                if let Some(v) = arr.get(idx) {
+                    current = v;
+                    continue;
+                }
+            }
+            return None;
+        }
+    }
+    Some(current)
+}
+
+/// Resolve a pointer using a field mapping as a hint.
+///
+/// Tries direct resolution first, then falls back to any of the
+/// mapping's location candidates. Returns the resolved node and
+/// the path that was actually used.
+pub fn resolve_pointer_with_mapping(
+    schema: &Value,
+    pointer: &str,
+    mapping: &FieldMapping,
+) -> Option<(Value, String)> {
+    // Try direct resolution first
+    if let Some(node) = resolve_pointer(schema, pointer) {
+        if !node.is_null() {
+            return Some((node.clone(), pointer.to_string()));
+        }
+    }
+
+    // Try each path component as a mapping key
+    let parts: Vec<&str> = pointer
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|p| !p.is_empty())
+        .collect();
+
+    for (i, part) in parts.iter().enumerate() {
+        if let Some(entry) = mapping.get(*part) {
+            for location in &entry.locations {
+                let location_clean = location.trim_start_matches('#').trim_start_matches('/');
+                // Try the location directly
+                if let Some(node) = resolve_pointer(schema, location_clean) {
+                    return Some((node.clone(), location_clean.to_string()));
+                }
+                // Try the location with the remaining path appended
+                if i < parts.len() - 1 {
+                    let remaining = parts[i + 1..].join("/");
+                    let combined = format!("{}/{}", location_clean, remaining);
+                    if let Some(node) = resolve_pointer(schema, &combined) {
+                        return Some((node.clone(), combined));
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Translate a federation field set (e.g., `"id contractId"`) by
+/// applying the field mapping to each token.
+///
+/// Federation keys reference fields in their source-form; this
+/// function maps source field names to their GraphQL equivalents.
+pub fn translate_federation_field_set(
+    field_set: &str,
+    mapping: &FieldMapping,
+    transform: Option<&dyn Fn(&str) -> String>,
+) -> String {
+    field_set
+        .split_whitespace()
+        .map(|token| {
+            // Check the mapping first
+            if let Some(entry) = mapping.get(token) {
+                if let Some(ref camel) = entry.camel {
+                    return camel.clone();
+                }
+            }
+            // Apply optional transform
+            if let Some(t) = transform {
+                t(token)
+            } else {
+                token.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Get all mapped locations for a given field name.
+pub fn locations_for(mapping: &FieldMapping, field_name: &str) -> Vec<String> {
+    mapping
+        .get(field_name)
+        .map(|e| e.locations.clone())
+        .unwrap_or_default()
+}
+
+/// Build an inverse mapping (GraphQL field name → snake_case source field).
+pub fn inverse_mapping(mapping: &FieldMapping) -> FieldMapping {
+    let mut inverse = FieldMapping::new();
+    for (key, entry) in mapping {
+        let mut inv = entry.clone();
+        // Swap snake and camel
+        inv.snake = entry.camel.clone().or_else(|| Some(key.clone()));
+        inv.camel = entry.snake.clone().or_else(|| Some(key.clone()));
+        inverse.insert(entry.camel.clone().unwrap_or_else(|| key.clone()), inv);
+    }
+    inverse
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_resolve_pointer_direct() {
+        let schema = json!({
+            "properties": {
+                "user_id": {"type": "string"}
+            }
+        });
+        let result = resolve_pointer(&schema, "/properties/user_id").unwrap();
+        assert_eq!(result.get("type").and_then(|v| v.as_str()), Some("string"));
+    }
+
+    #[test]
+    fn test_resolve_pointer_camel_snake_variants() {
+        let schema = json!({
+            "properties": {
+                "user_id": {"type": "string"}
+            }
+        });
+        let result = resolve_pointer(&schema, "/properties/userId").unwrap();
+        assert_eq!(result.get("type").and_then(|v| v.as_str()), Some("string"));
+    }
+
+    #[test]
+    fn test_parse_field_mapping_object_form() {
+        let json = json!({
+            "userId": {
+                "snake": "user_id",
+                "locations": ["/properties/user_id", "/$defs/User/properties/user_id"]
+            }
+        });
+        let mapping = parse_field_mapping(&json);
+        assert!(mapping.contains_key("userId"));
+        assert_eq!(mapping["userId"].snake, Some("user_id".to_string()));
+        assert_eq!(mapping["userId"].locations.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_field_mapping_shorthand() {
+        let json = json!({
+            "id": "/properties/id"
+        });
+        let mapping = parse_field_mapping(&json);
+        assert_eq!(mapping["id"].locations, vec!["/properties/id"]);
+    }
+
+    #[test]
+    fn test_resolve_pointer_with_mapping() {
+        let schema = json!({
+            "properties": {
+                "user_id": {"type": "string"}
+            }
+        });
+        let mut mapping = FieldMapping::new();
+        mapping.insert(
+            "userId".to_string(),
+            FieldMappingEntry {
+                snake: Some("user_id".to_string()),
+                camel: Some("userId".to_string()),
+                locations: vec!["properties/user_id".to_string()],
+            },
+        );
+        let (node, _path) =
+            resolve_pointer_with_mapping(&schema, "/properties/userId", &mapping).unwrap();
+        assert_eq!(node.get("type").and_then(|v| v.as_str()), Some("string"));
+    }
+
+    #[test]
+    fn test_translate_federation_field_set() {
+        let mut mapping = FieldMapping::new();
+        mapping.insert(
+            "user_id".to_string(),
+            FieldMappingEntry {
+                snake: Some("user_id".to_string()),
+                camel: Some("userId".to_string()),
+                locations: vec![],
+            },
+        );
+        let result = translate_federation_field_set("user_id email", &mapping, None);
+        assert_eq!(result, "userId email");
+    }
+
+    #[test]
+    fn test_locations_for() {
+        let mut mapping = FieldMapping::new();
+        mapping.insert(
+            "id".to_string(),
+            FieldMappingEntry {
+                snake: None,
+                camel: None,
+                locations: vec!["/a".to_string(), "/b".to_string()],
+            },
+        );
+        assert_eq!(locations_for(&mapping, "id").len(), 2);
+        assert_eq!(locations_for(&mapping, "missing").len(), 0);
+    }
+
+    #[test]
+    fn test_inverse_mapping() {
+        let mut mapping = FieldMapping::new();
+        mapping.insert(
+            "userId".to_string(),
+            FieldMappingEntry {
+                snake: Some("user_id".to_string()),
+                camel: Some("userId".to_string()),
+                locations: vec![],
+            },
+        );
+        let inv = inverse_mapping(&mapping);
+        // After inverse, the key is the camel form, and snake becomes "userId"
+        assert!(inv.contains_key("userId"));
+    }
+}

--- a/converters/rust/src/mapping/mod.rs
+++ b/converters/rust/src/mapping/mod.rs
@@ -4,9 +4,6 @@
 //! multiple candidate locations per field (JSON pointers) and pointer
 //! resolution that prefers mapped locations before falling back to
 //! direct resolution.
-//!
-//! Ported from TTSE-petrified-forest's `field-mapping-helper.mjs` and
-//! the `fieldMapping` parameter in `ir-to-graphql.mjs`.
 
 use serde_json::Value;
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary

This PR adds P1 features (analysis, mapping, DDL) to the core converter as standalone, well-tested modules.

## Groups Implemented

### Group 5: Schema Analysis Module (`analysis`)
- `SchemaStats`: per-type field counts, federation key detection, reference count, max depth, unique field names
- `compute_stats`: aggregate statistics across all definitions
- `DiffResult`: added/removed/modified type and field differences
- `diff_schemas`: compare two JSON Schemas with breaking-change detection
- `CoverageReport`: per-type and overall field mapping percentages
- `compute_field_coverage_by_name`: compute source-to-target coverage
- `compute_coverage`: coverage from explicit field mappings
- Human-readable formatters for both diffs and coverage

### Group 6: Field Mapping System (`mapping`)
- `FieldMappingEntry` with snake/camel/locations
- Parse field mappings from JSON (object, array, or string shorthand)
- `resolve_pointer` with camel/snake case variants
- `resolve_pointer_with_mapping`: tries direct resolution first, falls back to mapping locations
- `translate_federation_field_set`: for @key directive translation
- `inverse_mapping`: for GraphQL → source field lookups

### Group 7: Schema → DDL Pipeline (`ddl`)
- `RelationalSchema` with `TableDef`, `ColumnDef`, `RelationDef`
- `schema_to_relational`: decompose JSON Schema into tables
  - Objects become tables
  - Arrays of objects/scalars become child tables
  - Nested objects become 1:1 child tables with FK
  - Primary key inferred from id, global_record_id, or sole non-nullable
- `map_json_type_to_sql`: JSON Schema type → Spark/Delta type
  - `integer` → BIGINT (unbounded, faithful reflection)
  - Format-aware date-time/date mapping
  - Enum values preserved
- `generate_ddl`: Spark/Delta `CREATE TABLE` statements

### Group 7b: Mermaid ER Diagram (`diagram`)
- `mermaid_entity_name`: sanitize names for Mermaid
- `mermaid_type`: normalize SQL types (date-time → datetime)
- `to_mermaid_er`: generate erDiagram with PK/FK annotations
- `to_mermaid_markdown`: wrap in markdown with title

## Test Results
- **83 unit tests** (15 analysis, 8 mapping, 7 DDL, 4 diagram, plus existing 49)
- **60 integration tests** — all passing
- All pre-commit hooks (fmt, clippy, test) passing

## Use Cases
- Schema governance: `compute_stats(schema)` for metrics
- Schema evolution: `diff_schemas(old, new)` for breaking changes
- Multi-source unification: `FieldMapping` + `resolve_pointer_with_mapping`
- Data pipeline: `schema_to_relational(schema, root)` → DDL → tables
- Documentation: `to_mermaid_markdown(tables, relations)` → ER diagrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)